### PR TITLE
Performance improvements for async texture loading

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
-#
 # https://help.github.com/articles/dealing-with-line-endings/
-#
+
+# Default behavior for all files
+* text=auto
+
 # Linux start script should use lf
 /gradlew        text eol=lf
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loom_version=1.14-SNAPSHOT
 
 
 # Mod Properties
-mod_version=1.2.1
+mod_version=1.2.1-http-perf
 maven_group=larrytllama.pvcmappermod
 archives_base_name=pvc-mapper-mod
 

--- a/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
+++ b/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
@@ -203,26 +203,27 @@ public class FullScreenMap extends Screen {
     public void resetFeatures() {
         int tilesize = 1 << (17 - zoomlevel);
         double scale = (double) minimapTileSize / tilesize;
-        CompletableFuture.runAsync(() -> {
-            shownFeatures = pfu.fetchFeatures(
-                    currentDimension,
-                    x,
-                    (int) (x + (this.width / scale)),
-                    z,
-                    (int) (z + ((this.height - bottomMapOffset) / scale)));
-            isChangingFeatures = true;
-            // Convert bounds to coordinate format because grr weird format
-            for (int i = 0; i < shownFeatures.length; i++) {
-                if(shownFeatures[i].featureType.equals("area")) {
-                    if(shownFeatures[i].bounds == null) continue;
-                    for (int bound = 0; bound < shownFeatures[i].bounds.length; bound++) {
-                        shownFeatures[i].bounds[bound][0] = metersToPixels(shownFeatures[i].bounds[bound][0]);
-                        shownFeatures[i].bounds[bound][1] = metersToPixels(shownFeatures[i].bounds[bound][1]);
+        pfu.fetchFeaturesAsync(
+                currentDimension,
+                x,
+                (int) (x + (this.width / scale)),
+                z,
+                (int) (z + ((this.height - bottomMapOffset) / scale)))
+            .thenAccept(features -> {
+                shownFeatures = features;
+                isChangingFeatures = true;
+                // Convert bounds to coordinate format because grr weird format
+                for (int i = 0; i < shownFeatures.length; i++) {
+                    if(shownFeatures[i].featureType.equals("area")) {
+                        if(shownFeatures[i].bounds == null) continue;
+                        for (int bound = 0; bound < shownFeatures[i].bounds.length; bound++) {
+                            shownFeatures[i].bounds[bound][0] = metersToPixels(shownFeatures[i].bounds[bound][0]);
+                            shownFeatures[i].bounds[bound][1] = metersToPixels(shownFeatures[i].bounds[bound][1]);
+                        }
                     }
                 }
-            }
-            isChangingFeatures = false;
-        });
+                isChangingFeatures = false;
+            });
     }
 
     @Override
@@ -263,22 +264,23 @@ public class FullScreenMap extends Screen {
                         } else {
                             System.out.println("Feature clicked: " + shownFeatures[i].id);
                             int index = i;
-                            CompletableFuture.runAsync(() -> {
-                                overlayFeature = pfu.fetchArea(shownFeatures[index].id);
-                                overlayItemID = shownFeatures[index].id;
-                                overlayItemType = "area";
-                                overlayOpen = true;
-                                overlayImage = null;
-                                overlayImageStatus = "Loading...";
-                                if(overlayFeature.area.image != null) {
-                                    TextureUtils.fetchRemoteTexture(overlayFeature.area.image, (id) -> {
-                                        overlayImage = id;
+                            pfu.fetchAreaAsync(shownFeatures[index].id)
+                                .thenAccept(feature -> {
+                                    overlayFeature = feature;
+                                    overlayItemID = shownFeatures[index].id;
+                                    overlayItemType = "area";
+                                    overlayOpen = true;
+                                    overlayImage = null;
+                                    overlayImageStatus = "Loading...";
+                                    if(overlayFeature.area.image != null) {
+                                        TextureUtils.fetchImmediateRemoteTexture(overlayFeature.area.image, (id) -> {
+                                            overlayImage = id;
+                                            overlayImageStatus = "No image available";
+                                        });
+                                    } else {
                                         overlayImageStatus = "No image available";
-                                    });
-                                } else {
-                                    overlayImageStatus = "No image available";
-                                }
-                            });
+                                    }
+                                });
                         }
 
                     }
@@ -293,22 +295,23 @@ public class FullScreenMap extends Screen {
                                 if(mbe.hasControlDown()) {
                                     minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                                 } else {
-                                    CompletableFuture.runAsync(() -> {
-                                        overlayFeature = pfu.fetchPlace(shownFeatures[index].id);
-                                        overlayItemID = shownFeatures[index].id;
-                                        overlayItemType = "place";
-                                        overlayOpen = true;
-                                        overlayImage = null;
-                                        overlayImageStatus = "Loading...";
-                                        if(overlayFeature.place.images != null) {
-                                            TextureUtils.fetchRemoteTexture(overlayFeature.place.images, (id) -> {
-                                                overlayImage = id;
+                                    pfu.fetchPlaceAsync(shownFeatures[index].id)
+                                        .thenAccept(feature -> {
+                                            overlayFeature = feature;
+                                            overlayItemID = shownFeatures[index].id;
+                                            overlayItemType = "place";
+                                            overlayOpen = true;
+                                            overlayImage = null;
+                                            overlayImageStatus = "Loading...";
+                                            if(overlayFeature.place.images != null) {
+                                                TextureUtils.fetchImmediateRemoteTexture(overlayFeature.place.images, (id) -> {
+                                                    overlayImage = id;
+                                                    overlayImageStatus = "No image available";
+                                                });
+                                            } else {
                                                 overlayImageStatus = "No image available";
-                                            });
-                                        } else {
-                                            overlayImageStatus = "No image available";
-                                        }
-                                    });
+                                            }
+                                        });
                                 }
                                 break;
 
@@ -820,14 +823,13 @@ public class FullScreenMap extends Screen {
                                 playerMarkerChoice = pfu.OTHER_PLAYERS_OW;
                                 break;
                             case "minecraft_the_nether":
-                                playerMarkerChoice = pfu.OTHER_PLAYERS_NETHER;
-                                break;
-                            default:
-                                playerMarkerChoice = pfu.OTHER_PLAYERS_SOMEWHERE;
-                                break;
-                        }
+                            playerMarkerChoice = pfu.OTHER_PLAYERS_NETHER;
+                            break;
+                        default:
+                            playerMarkerChoice = pfu.OTHER_PLAYERS_SOMEWHERE;
+                            break;
                     }
-
+                    }
                     context.blit(
                             RenderPipelines.GUI_TEXTURED,
                             playerMarkerChoice,
@@ -968,8 +970,7 @@ public class FullScreenMap extends Screen {
         }).bounds(this.width - 25, 30, 20, 20).tooltip(Tooltip.create(Component.literal("PVC Mapper Mod Settings"))).build();
         
         // Add sponsor banner code here
-        CompletableFuture.runAsync(() -> {
-            SponsorBanner banner = SponsorUtils.getBanner();
+        SponsorUtils.getBannerAsync().thenAccept(banner -> {
             SponsorUtils.bannerToTexture(banner.imgurl, (rl) -> {
                 this.sponsorBanner = rl;
             });

--- a/src/client/java/larrytllama/pvcmappermod/MapperCmdHandler.java
+++ b/src/client/java/larrytllama/pvcmappermod/MapperCmdHandler.java
@@ -24,16 +24,6 @@ import java.time.Instant;
 
 public class MapperCmdHandler {
 
-    // https://stackoverflow.com/a/13632114
-    public static String readStringFromURL(String requestURL) throws IOException {
-        try (Scanner scanner = new Scanner(URI.create(requestURL).toURL().openStream(),
-                StandardCharsets.UTF_8.toString()))
-        {
-            scanner.useDelimiter("\\A");
-            return scanner.hasNext() ? scanner.next() : "";
-        }
-    }
-
     public PlayerFetchUtils pfu;
 
     public MapperCmdHandler(PlayerFetchUtils pfu, PVCMapperModClient modclient) {
@@ -51,8 +41,7 @@ public class MapperCmdHandler {
                         });
                         return 1;
                     }
-                    CompletableFuture.runAsync(() -> {
-                        SearchResult[] results = pfu.fetchSearchResults(query);
+                    pfu.fetchSearchResultsAsync(query).thenAccept(results -> {
                         if(results == null) {
                             Minecraft.getInstance().execute(() -> {
                                 context.getSource().sendError(Component.literal("Search failed. Try again later!").withStyle(ChatFormatting.RED));

--- a/src/client/java/larrytllama/pvcmappermod/Minimap.java
+++ b/src/client/java/larrytllama/pvcmappermod/Minimap.java
@@ -432,7 +432,7 @@ public class Minimap {
                         String thisDimension = getDimensionNID().equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : getDimensionNID();
                         String url = String.format("%s%s/%d/%d_%d.png",
                             sp.mapTileSource, thisDimension, zoomlevel, i, i2);
-                        TextureUtils.fetchRemoteTexture(url, (id) -> {
+                        TextureUtils.fetchImmediateRemoteTexture(url, (id) -> {
                             textureLocations[indexToSet] = id;
                         });
                     }
@@ -449,23 +449,33 @@ public class Minimap {
             tileCoords[3][1] = divZ + 1;
 
             // Add places in too
-            CompletableFuture.runAsync(() -> {
-                int minx = tileCoords[0][0] * tilesize;
-                int maxx = (tileCoords[3][0] * tilesize) + tilesize;
-                int minz = tileCoords[0][1] * tilesize;
-                int maxz = (tileCoords[3][1] * tilesize) + tilesize;
-                try (Scanner scanner = new Scanner(new URI(
-                        String.format("https://pvc.coolwebsite.uk/api/v1/fetch/places/%s/%d/%d/%d/%d",
-                            getDimensionNID(), minx, maxx, minz, maxz))
-                        .toURL().openStream(), "UTF-8")) {
-                    String out = scanner.useDelimiter("\\A").next();
-                    Gson gson = new Gson();
-                    placesList = new ArrayList<PlaceFetch>(Arrays.asList(gson.fromJson(out, PlaceFetch[].class)));
-                } catch (Exception e) {
-                    System.out.println("Failed to fetch places from PVC Mapper!");
-                    System.out.println(e);
-                }
-            });
+            int minx = tileCoords[0][0] * tilesize;
+            int maxx = (tileCoords[3][0] * tilesize) + tilesize;
+            int minz = tileCoords[0][1] * tilesize;
+            int maxz = (tileCoords[3][1] * tilesize) + tilesize;
+            try {
+                java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                    .uri(new URI(String.format("https://pvc.coolwebsite.uk/api/v1/fetch/places/%s/%d/%d/%d/%d",
+                        getDimensionNID(), minx, maxx, minz, maxz)))
+                    .GET().build();
+                NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                    .thenAccept(response -> {
+                        if (response.statusCode() == 200) {
+                            Gson gson = new Gson();
+                            placesList = new ArrayList<PlaceFetch>(Arrays.asList(gson.fromJson(response.body(), PlaceFetch[].class)));
+                        } else {
+                            System.out.println("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
+                        }
+                    })
+                    .exceptionally(e -> {
+                        System.out.println("Failed to fetch places from PVC Mapper!");
+                        System.out.println(e);
+                        return null;
+                    });
+            } catch (Exception e) {
+                System.out.println("Failed to fetch places from PVC Mapper!");
+                System.out.println(e);
+            }
 
             hasNotBeenInitialisedYet = false;
         }

--- a/src/client/java/larrytllama/pvcmappermod/NetworkUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/NetworkUtils.java
@@ -1,0 +1,16 @@
+package larrytllama.pvcmappermod;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+public class NetworkUtils {
+    /**
+     * Singleton HTTP Client instance.
+     * Reuses connections, prevents socket exhaustion, and shifts logic off the main thread.
+     */
+    public static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_2)
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+}

--- a/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
@@ -5,7 +5,6 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -65,13 +64,36 @@ public class PlayerFetchUtils {
                         stopUpdates();
                         return;
                     }
-                    try (Scanner scanner = new Scanner(
-                            new URI("https://pvc.coolwebsite.uk/api/v1/players").toURL().openStream(), "UTF-8")) {
-                        String out = scanner.useDelimiter("\\A").next();
-                        Gson gson = new Gson();
-                        playersList = new ArrayList<PlayerFetch>(
-                                Arrays.asList(gson.fromJson(out, PlayerFetch[].class)));
-                        errorCount = 0;
+                    try {
+                        java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                            .uri(new URI("https://pvc.coolwebsite.uk/api/v1/players"))
+                            .GET().build();
+                        NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                            .thenAccept(response -> {
+                                if (response.statusCode() == 200) {
+                                    Gson gson = new Gson();
+                                    playersList = new ArrayList<PlayerFetch>(
+                                            Arrays.asList(gson.fromJson(response.body(), PlayerFetch[].class)));
+                                    errorCount = 0;
+                                } else {
+                                    errorCount += 1;
+                                    System.out.println("Failed to fetch players. Status: " + response.statusCode());
+                                    if(errorCount > 3) { // Avoid toast-spam
+                                        showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Relog to retry live tracking.");
+                                        stopUpdates();
+                                    }
+                                }
+                            })
+                            .exceptionally(e -> {
+                                errorCount += 1;
+                                if(errorCount > 3) {
+                                    showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Relog to retry live tracking.");
+                                    stopUpdates();
+                                }
+                                System.out.println("Failed to fetch players from PVC Mapper!");
+                                System.out.println(e);
+                                return null;
+                            });
                     } catch (Exception e) {
                         errorCount += 1;
                         showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Relog to retry live tracking.");
@@ -192,46 +214,86 @@ public class PlayerFetchUtils {
 
     public void fetchClaims() {
         System.out.println("Fetching claims from https://pvc.coolwebsite.uk/api/v1/claims");
-        try (Scanner scanner = new Scanner(new URI("https://pvc.coolwebsite.uk/api/v1/claims").toURL().openStream(),
-                "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new GsonBuilder()
-                    .registerTypeAdapter(ClaimFetch.class, new ClaimMarkerDeserialize())
-                    .create();
-            claimsList = gson.fromJson(out, ClaimFetch.class);
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/claims"))
+                .GET().build();
+            NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenAccept(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new GsonBuilder()
+                                .registerTypeAdapter(ClaimFetch.class, new ClaimMarkerDeserialize())
+                                .create();
+                        claimsList = gson.fromJson(response.body(), ClaimFetch.class);
+                    } else {
+                        System.out.println("Failed to fetch claims from PVC Mapper! Code: " + response.statusCode());
+                    }
+                })
+                .exceptionally(e -> {
+                    System.out.println("Failed to fetch claims from PVC Mapper!");
+                    System.out.println(e);
+                    return null;
+                });
         } catch (Exception e) {
             //showToast("Mapper Connect Error", "Check your internet connection?");
             System.out.println("Failed to fetch claims from PVC Mapper!");
             System.out.println(e);
         }
+
         // Get nether claims too!
-        try (Scanner scanner = new Scanner(new URI("https://pvc.coolwebsite.uk/api/v1/claims/nether").toURL().openStream(),
-                "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new GsonBuilder()
-                    .registerTypeAdapter(ClaimFetch.class, new ClaimMarkerDeserialize())
-                    .create();
-            netherClaimsList = gson.fromJson(out, ClaimFetch.class);
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/claims/nether"))
+                .GET().build();
+            NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenAccept(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new GsonBuilder()
+                                .registerTypeAdapter(ClaimFetch.class, new ClaimMarkerDeserialize())
+                                .create();
+                        netherClaimsList = gson.fromJson(response.body(), ClaimFetch.class);
+                    } else {
+                        System.out.println("Failed to fetch nether claims from PVC Mapper! Code: " + response.statusCode());
+                    }
+                })
+                .exceptionally(e -> {
+                    System.out.println("Failed to fetch nether claims from PVC Mapper!");
+                    System.out.println(e);
+                    return null;
+                });
         } catch (Exception e) {
-            //showToast("Mapper Connect Error", "Check your internet connection?");
-            System.out.println("Failed to fetch claims from PVC Mapper!");
+            System.out.println("Failed to fetch nether claims from PVC Mapper!");
             System.out.println(e);
         }
     }
 
-    public FeatureFetch[] fetchFeatures(String dimension, int x1, int x2, int z1, int z2) {
+    public CompletableFuture<FeatureFetch[]> fetchFeaturesAsync(String dimension, int x1, int x2, int z1, int z2) {
         String url = String.format("https://pvc.coolwebsite.uk/api/v2/fetch/things/%s/%d/%d/%d/%d", dimension, x1, x2, z1, z2);
         System.out.println("Fetching all features in area from PVC Mapper.");
-        try (Scanner scanner = new Scanner(new URI(url).toURL().openStream(),
-                "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            return gson.fromJson(out, FeatureFetch[].class);
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI(url))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        FeatureFetch[] features = gson.fromJson(response.body(), FeatureFetch[].class);
+                        return features;
+                    }
+                    return new FeatureFetch[0];
+                })
+                .exceptionally(e -> {
+                    showToast("Mapper Connect Error", "Check your internet connection?");
+                    System.out.println("Failed to fetch features from PVC Mapper!");
+                    System.out.println(e);
+                    return new FeatureFetch[0];
+                });
         } catch (Exception e) {
             showToast("Mapper Connect Error", "Check your internet connection?");
             System.out.println("Failed to fetch features from PVC Mapper!");
             System.out.println(e);
-            return new FeatureFetch[0];
+            return CompletableFuture.completedFuture(new FeatureFetch[0]);
         }
     }
 
@@ -302,23 +364,37 @@ public class PlayerFetchUtils {
         }
     }
 
-    public FeatureTypes fetchPlace(int placeId) {
-        FeatureTypes ft = new FeatureTypes();
+    public CompletableFuture<FeatureTypes> fetchPlaceAsync(int placeId) {
         System.out.println("Fetching place with ID: " + placeId);
-        try (Scanner scanner = new Scanner(
-            new URI("https://pvc.coolwebsite.uk/api/v1/fetch/places/byid/" + placeId).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            ft.place = gson.fromJson(out, PlacesFetch.class);
-            return ft;
-        } catch (FileNotFoundException e) {
-            showToast("Place not found!", "The place may have just been deleted.");
-            return ft;
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/fetch/places/byid/" + placeId))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    FeatureTypes ft = new FeatureTypes();
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        ft.place = gson.fromJson(response.body(), PlacesFetch.class);
+                    } else if (response.statusCode() == 404) {
+                        showToast("Place not found!", "The place may have just been deleted.");
+                    } else {
+                        showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                        System.out.println("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
+                    }
+                    return ft;
+                })
+                .exceptionally(e -> {
+                    showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                    System.out.println("Failed to fetch places from PVC Mapper!");
+                    System.out.println(e);
+                    return new FeatureTypes();
+                });
         } catch (Exception e) {
-            showToast("Mapper Connect Error", "Check your connection and try again later!");
+            showToast("Mapper Connect Error", "Problem connecting, try again later!");
             System.out.println("Failed to fetch places from PVC Mapper!");
             System.out.println(e);
-            return ft;
+            return CompletableFuture.completedFuture(new FeatureTypes());
         }
     }
 
@@ -330,43 +406,74 @@ public class PlayerFetchUtils {
         return Math.round(num / getScale());
     }
 
-    public FeatureTypes fetchArea(int placeId) {
-        FeatureTypes ft = new FeatureTypes();
+    public CompletableFuture<FeatureTypes> fetchAreaAsync(int placeId) {
         System.out.println("Fetching area with ID: " + placeId);
-        try (Scanner scanner = new Scanner(
-            new URI("https://pvc.coolwebsite.uk/api/v1/fetch/area/byid/" + placeId).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            ft.area = gson.fromJson(out, AreasFetch.class);
-            System.out.println("X/Z: " + ft.area.x + " / " + ft.area.z);
-            ft.area.x = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.x))));
-            ft.area.z = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.z))));
-            return ft;
-        } catch (FileNotFoundException e) {
-            showToast("Area not found!", "The area may have just been deleted.");
-            return ft;
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/fetch/area/byid/" + placeId))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    FeatureTypes ft = new FeatureTypes();
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        ft.area = gson.fromJson(response.body(), AreasFetch.class);
+                        System.out.println("X/Z: " + ft.area.x + " / " + ft.area.z);
+                        ft.area.x = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.x))));
+                        ft.area.z = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.z))));
+                    } else if (response.statusCode() == 404) {
+                        showToast("Area not found!", "The area may have just been deleted.");
+                    } else {
+                        showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                        System.out.println("Failed to fetch areas from PVC Mapper! Code: " + response.statusCode());
+                    }
+                    return ft;
+                })
+                .exceptionally(e -> {
+                    showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                    System.out.println("Failed to fetch areas from PVC Mapper!");
+                    System.out.println(e);
+                    return new FeatureTypes();
+                });
         } catch (Exception e) {
-            showToast("Mapper Connect Error", "Check your connection and try again later!");
-            System.out.println("Failed to fetch places from PVC Mapper!");
+            showToast("Mapper Connect Error", "Problem connecting, try again later!");
+            System.out.println("Failed to fetch areas from PVC Mapper!");
             System.out.println(e);
-            return ft;
+            return CompletableFuture.completedFuture(new FeatureTypes());
         }
     }
 
-    public SearchResult[] fetchSearchResults(String query) {
-        try (Scanner scanner = new Scanner(
-            new URI("https://pvc.coolwebsite.uk/api/v2/search/" + query).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            return gson.fromJson(out, SearchResult[].class);
-        } catch (FileNotFoundException e) {
-            showToast("Search not available!", "Try again later! :(");
-            return null;
+    public CompletableFuture<SearchResult[]> fetchSearchResultsAsync(String query) {
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v2/search/" + query))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        SearchResult[] results = gson.fromJson(response.body(), SearchResult[].class);
+                        return results;
+                    } else if (response.statusCode() == 404) {
+                        showToast("Search not available!", "Try again later! :(");
+                        return null;
+                    } else {
+                        showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                        System.out.println("Failed to fetch search from PVC Mapper! Code: " + response.statusCode());
+                        return null;
+                    }
+                })
+                .exceptionally(e -> {
+                    showToast("Mapper Connect Error", "Problem connecting, try again later!");
+                    System.out.println("Failed to fetch search from PVC Mapper!");
+                    System.out.println(e);
+                    return null;
+                });
         } catch (Exception e) {
-            showToast("Mapper Connect Error", "Check your connection and try again later!");
-            System.out.println("Failed to fetch places from PVC Mapper!");
+            showToast("Mapper Connect Error", "Problem connecting, try again later!");
+            System.out.println("Failed to fetch search from PVC Mapper!");
             System.out.println(e);
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
     }
 
@@ -381,21 +488,39 @@ public class PlayerFetchUtils {
         }
         System.out.println("Checking for updates from https://pvc.coolwebsite.uk/mod/downloads/modversions.json...");
         System.out.println("Current version: " + McVersionName + ", " + MapperModVersionName);
-        try (Scanner scanner = new Scanner(
-            new URI("https://pvc.coolwebsite.uk/mod/downloads/modversions.json").toURL().openStream(), "UTF-8"
-        )) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            VersionHistory[] vh = gson.fromJson(out, VersionHistory[].class);
-            for (int i = 0; i < vh.length; i++) {
-                if(vh[i].mcVersion.equals(McVersionName)) {
-                    System.out.println("Version for this MC version is found! v" + vh[i].version);
-                    if(!vh[i].version.equals(MapperModVersionName)) {
-                        Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToastId.PERIODIC_NOTIFICATION, Component.literal("PVC Mapper Mod Updates"), Component.literal("v" +vh[i].version + " now available! See website for details.")));
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/mod/downloads/modversions.json"))
+                .GET().build();
+            NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenAccept(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        VersionHistory[] vh = gson.fromJson(response.body(), VersionHistory[].class);
+                        for (int i = 0; i < vh.length; i++) {
+                            if(vh[i].mcVersion.equals(McVersionName)) {
+                                System.out.println("Version for this MC version is found! v" + vh[i].version);
+                                final String newVersion = vh[i].version;
+                                if(!newVersion.equals(MapperModVersionName)) {
+                                    Minecraft.getInstance().execute(() -> {
+                                        Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToastId.PERIODIC_NOTIFICATION, Component.literal("PVC Mapper Mod Updates"), Component.literal("v" + newVersion + " now available! See website for details.")));
+                                    });
+                                }
+                                return;
+                            }
+                        }
+                    } else {
+                        Minecraft.getInstance().execute(() -> {
+                            Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToastId.PERIODIC_NOTIFICATION, Component.literal("PVC Mapper Mod Error"), Component.literal("Check for updates failed.")));
+                        });
                     }
-                    return;
-                }
-            }
+                })
+                .exceptionally(e -> {
+                    Minecraft.getInstance().execute(() -> {
+                        Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToastId.PERIODIC_NOTIFICATION, Component.literal("PVC Mapper Mod Error"), Component.literal("Check for updates failed.")));
+                    });
+                    return null;
+                });
         } catch (Exception e) {
             Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToastId.PERIODIC_NOTIFICATION, Component.literal("PVC Mapper Mod Error"), Component.literal("Check for updates failed. The Mapper may be down!")));
         }

--- a/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
@@ -77,7 +77,7 @@ public class PlayerFetchUtils {
                                     errorCount = 0;
                                 } else {
                                     errorCount += 1;
-                                    System.out.println("Failed to fetch players. Status: " + response.statusCode());
+                                    System.out.println("Failed to fetch players from PVC Mapper! Code: " + response.statusCode());
                                     if(errorCount > 3) { // Avoid toast-spam
                                         showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Relog to retry live tracking.");
                                         stopUpdates();

--- a/src/client/java/larrytllama/pvcmappermod/ShopsHandler.java
+++ b/src/client/java/larrytllama/pvcmappermod/ShopsHandler.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 
 import com.google.gson.Gson;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
 
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -59,48 +59,80 @@ public class ShopsHandler {
         return items;
     }
 
-    public static Shop[] shopsByItem(String item) {
-        try (Scanner scanner = new Scanner(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByItem/" + item).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            Shop[] shops = gson.fromJson(out, Shop[].class);
-            return shops;
+    public static CompletableFuture<Shop[]> shopsByItemAsync(String item) {
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByItem/" + item))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        Shop[] shops = gson.fromJson(response.body(), Shop[].class);
+                        return shops;
+                    }
+                    return new Shop[0];
+                })
+                .exceptionally(e -> {
+                    e.printStackTrace();
+                    return new Shop[0];
+                });
         } catch(Exception e) {
-            return new Shop[0];
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(new Shop[0]);
         }
     }
 
-    public static Shop[] shopsByPlayer(String username) {
+    public static CompletableFuture<Shop[]> shopsByPlayerAsync(String username) {
         try {
-        System.out.println(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByPlayer/" + username).toURL().toString());
+            System.out.println("Fetching shops for " + username);
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByPlayer/" + username))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        Shop[] shops = gson.fromJson(response.body(), Shop[].class);
+                        System.out.println(shops.length);
+                        return shops;
+                    }
+                    return new Shop[0];
+                })
+                .exceptionally(e -> {
+                    System.out.println(e);
+                    e.printStackTrace();
+                    return new Shop[0];
+                });
         } catch(Exception e) {
-            // Whatevs
             System.out.println(e);
             e.printStackTrace();
-        }
-        try (Scanner scanner = new Scanner(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByPlayer/" + username).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            Shop[] shops = gson.fromJson(out, Shop[].class);
-            System.out.println(shops.length);
-            return shops;
-        } catch(Exception e) {
-            
-            System.out.println(e);
-            e.printStackTrace();
-            return new Shop[0];
+            return CompletableFuture.completedFuture(new Shop[0]);
         }
     }
 
     // Possible use later. I'll see if I fancy it
-    public static ShopsPlayerStats shopsStatsByPlayer(String username) {
-        try (Scanner scanner = new Scanner(new URI("https://pvc.coolwebsite.uk/pvc-utils/playerStats/" + username).toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            ShopsPlayerStats shops = gson.fromJson(out, ShopsPlayerStats.class);
-            return shops;
+    public static CompletableFuture<ShopsPlayerStats> shopsStatsByPlayerAsync(String username) {
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/playerStats/" + username))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        ShopsPlayerStats stats = gson.fromJson(response.body(), ShopsPlayerStats.class);
+                        return stats;
+                    }
+                    return new ShopsPlayerStats();
+                })
+                .exceptionally(e -> {
+                    e.printStackTrace();
+                    return new ShopsPlayerStats();
+                });
         } catch(Exception e) {
-            return new ShopsPlayerStats();
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(new ShopsPlayerStats());
         }
     }
 

--- a/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
+++ b/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
@@ -123,8 +123,7 @@ public class ShopsScreen extends Screen {
             );
         this.addRenderableWidget(searchMode);
 
-        CompletableFuture.runAsync(() -> {
-            SponsorBanner banner = SponsorUtils.getBanner();
+        SponsorUtils.getBannerAsync().thenAccept(banner -> {
             SponsorUtils.bannerToTexture(banner.imgurl, (rl) -> {
                 this.sponsorBanner = rl;
             });
@@ -143,7 +142,7 @@ public class ShopsScreen extends Screen {
             else Minecraft.getInstance().setScreen(null);
         } else if(itemSearch.isFocused()) {
             if(keyEvent.key() == GLFW.GLFW_KEY_TAB) {
-                if(filteredItems.length > 0) itemSearch.setValue(filteredItems[0]);
+                itemSearch.setValue(filteredItems[0]);
             } else if(keyEvent.key() == GLFW.GLFW_KEY_ENTER) {
                 if(currentSearchMode.equals("item")) this.openWithItem(this.itemSearch.getValue());
                 else if(currentSearchMode.equals("username")) this.openWithUsername(this.itemSearch.getValue());
@@ -212,7 +211,7 @@ public class ShopsScreen extends Screen {
         // Make a request for the tile
         String url = String.format("%s%s/8/%d_%d.png",
             "https://pvc.coolwebsite.uk/maps/", dimension, tileX, tileZ);
-        TextureUtils.fetchRemoteTexture(url, (id) -> {
+        TextureUtils.fetchImmediateRemoteTexture(url, (id) -> {
             tiles.put(String.format("%s/8/%d_%d", dimension, tileX, tileZ), id);
         });
     }
@@ -336,8 +335,7 @@ public class ShopsScreen extends Screen {
 
     public void openWithItem(String itemID) {
         final String item = itemID;
-        CompletableFuture
-                .supplyAsync(() -> ShopsHandler.shopsByItem(item))
+        ShopsHandler.shopsByItemAsync(item)
                 .thenAccept(shops -> Minecraft.getInstance().execute(() -> {
                     list.removeAllWidgets();
                     for (int i = 0; i < shops.length; i++) {
@@ -351,8 +349,7 @@ public class ShopsScreen extends Screen {
 
     public void openWithUsername(String username) {
         final String user = username;
-        CompletableFuture
-            .supplyAsync(() -> ShopsHandler.shopsByPlayer(user))
+        ShopsHandler.shopsByPlayerAsync(user)
             .thenAccept((shops) -> Minecraft.getInstance().execute(() -> {
                 list.removeAllWidgets();
                 for (int i = 0; i < shops.length; i++) {

--- a/src/client/java/larrytllama/pvcmappermod/SponsorUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/SponsorUtils.java
@@ -3,9 +3,9 @@ package larrytllama.pvcmappermod;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.Base64;
-import java.util.Scanner;
 import java.util.Base64.Decoder;
 import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.gson.Gson;
 import com.mojang.blaze3d.platform.NativeImage;
@@ -22,20 +22,31 @@ class SponsorBanner {
 }
 
 public class SponsorUtils {
-    public static SponsorBanner getBanner() {
-        System.out.println("Fetching sponsor banner from https://pvc.coolwebsite.uk/api/v1/sponsor-banner");
-        SponsorBanner sponsor;
-        try(Scanner scanner = new Scanner(
-            new URI("https://pvc.coolwebsite.uk/api/v1/sponsor-banner").toURL().openStream(), "UTF-8")) {
-            String out = scanner.useDelimiter("\\A").next();
-            Gson gson = new Gson();
-            sponsor = gson.fromJson(out, SponsorBanner.class);
+    public static CompletableFuture<SponsorBanner> getBannerAsync() {
+        System.out.println("Fetching sponsor banner from https://pvc.coolwebsite.uk/api/v1/sponsor-banner...");
+        try {
+            java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/sponsor-banner"))
+                .GET().build();
+            return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> {
+                    if (response.statusCode() == 200) {
+                        Gson gson = new Gson();
+                        SponsorBanner banner = gson.fromJson(response.body(), SponsorBanner.class);
+                        return banner;
+                    }
+                    return new SponsorBanner();
+                })
+                .exceptionally(e -> {
+                    System.out.println("Failed to fetch sponsor banners");
+                    e.printStackTrace();
+                    return new SponsorBanner();
+                });
         } catch(Exception e) {
-            sponsor = new SponsorBanner();
             System.out.println("Failed to fetch sponsor banners");
-            System.out.println(e);
+            e.printStackTrace();
+            return CompletableFuture.completedFuture(new SponsorBanner());
         }
-        return sponsor;
     }
 
     public static void bannerToTexture(String bannerDataURL, Consumer<ResourceLocation> callback) {

--- a/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
@@ -5,59 +5,152 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.resources.ResourceLocation;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URL;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class TextureUtils {
+    // Limits background tile downloads to prevent Cloudflare rate-limiting.
+    // Increased to 16 from 7-8 because the Stagger logic below prevents bursts. Could try higher.
+    private static final int MAX_CONCURRENT_DOWNLOADS = 16;
+    
+    // Global stagger to prevent Cloudflare/Origin challenges during initialization's fetches.
+    private static final java.util.concurrent.atomic.AtomicLong lastFetchTime = new java.util.concurrent.atomic.AtomicLong(0);
+    private static final int FETCH_STAGGER_MS = 50;
+
+    // LIFO ThreadPool: Prioritizes the most recently requested tiles over older, off-screen tiles.
+    private static final ExecutorService downloadExecutor = new ThreadPoolExecutor(
+            MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_DOWNLOADS, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingDeque<Runnable>() {
+                @Override
+                public boolean offer(Runnable e) {
+                    return super.offerFirst(e);
+                }
+            }
+    );
+    private static final ConcurrentHashMap<String, Long> failedFetches = new ConcurrentHashMap<>();
+    
     static ResourceLocation blurredTile = ResourceLocation.fromNamespaceAndPath("pvcmappermod","textures/gui/tileloading.png");
 
     /**
      * Fetches an image from a URL, converts it to a DynamicTexture, registers it,
-     * and returns the ResourceLocation via a callback.
+     * and returns the ResourceLocation via a callback. Uses the bounded download pool.
      *
      * @param urlString The URL of the image.
      * @param callback  The callback to run when the texture is ready.
      */
     public static void fetchRemoteTexture(String urlString, Consumer<ResourceLocation> callback) {
+        Long failedTime = failedFetches.get(urlString);
+        if (failedTime != null && (System.currentTimeMillis() - failedTime < 10000)) {
+            // Already failed recently. Use blurred tile silently.
+            callback.accept(blurredTile);
+            return;
+        }
+
         System.out.println("Fetching image from source: " + urlString);
-        CompletableFuture.runAsync(() -> {
-            try {
-                NativeImage image;
-                byte[] imgBytes = new URI(urlString.startsWith("https://") ? urlString : "https://pvc.coolwebsite.uk" + urlString).toURL().openStream().readAllBytes();
-
-                // Download and read the image off-thread
-                try (var input = new ByteArrayInputStream(imgBytes)) {
-                    image = NativeImage.read(input);
-                }
-
-                // Schedule registration on the main render thread
-                NativeImage finalImage = image;
-                Minecraft.getInstance().execute(() -> {
-                    String idStr = "remote_" + Integer.toHexString(urlString.hashCode());
-                    DynamicTexture dynamicTexture = new DynamicTexture(() -> idStr, finalImage);
-                    //dynamicTexture
-                    ResourceLocation resourceLocation = ResourceLocation.fromNamespaceAndPath("pvcmappermod", idStr);
-                    Minecraft.getInstance().getTextureManager().register(resourceLocation, dynamicTexture);
-                    callback.accept(resourceLocation);
-                });
-
-            } catch(FileNotFoundException e) {
-                callback.accept(blurredTile);
-            } catch (Exception e) {
-                callback.accept(null);
-                e.printStackTrace();
-            }
+        downloadExecutor.submit(() -> {
+            executeFetch(urlString, callback);
         });
     }
 
-    
+    /**
+     * Instantly fetches an image, bypassing the background tile queue.
+     * Intended exclusively for UI elements like POI overlays and banners.
+     */
+    public static void fetchImmediateRemoteTexture(String urlString, Consumer<ResourceLocation> callback) {
+        System.out.println("Fetching immediate UI image from source: " + urlString);
+        CompletableFuture.runAsync(() -> {
+            executeFetch(urlString, callback);
+        });
+    }
+
+    private static void executeFetch(String urlString, Consumer<ResourceLocation> callback) {
+        // Apply Global Stagger to avoid overwhelming the server/Cloudflare with bursts from initialization
+        try {
+            long now = System.currentTimeMillis();
+            long nextTime = lastFetchTime.updateAndGet(last -> Math.max(last + FETCH_STAGGER_MS, now));
+            long sleepTime = nextTime - now;
+            if (sleepTime > 0) {
+                Thread.sleep(sleepTime);
+            }
+        } catch (InterruptedException ignored) {}
+
+        try {
+            String targetUrl = urlString.startsWith("https://") ? urlString : "https://pvc.coolwebsite.uk" + urlString;
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(new URI(targetUrl))
+                    .GET()
+                    .build();
+
+            // Use InputStream handler for memory efficiency (pipes directly to NativeImage)
+            HttpResponse<InputStream> response = NetworkUtils.HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            if (response.statusCode() == 404) {
+                Minecraft.getInstance().execute(() -> callback.accept(blurredTile));
+                return;
+            }
+            
+            if (response.statusCode() != 200) {
+                System.out.println("[TextureUtils Error] Failed to fetch tile: " + urlString + " (HTTP " + response.statusCode() + ")");
+                failedFetches.put(urlString, System.currentTimeMillis());
+                Minecraft.getInstance().execute(() -> callback.accept(blurredTile)); // using blurredTile so we don't return null
+                return;
+            }
+
+            // Check if Cloudflare served an explicit HTML challenge instead of an image
+            String contentType = response.headers().firstValue("Content-Type").orElse("");
+            if (contentType.contains("text/html")) {
+                handleSoftRateLimit(urlString, "Cloudflare Challenge", callback);
+                return;
+            }
+
+            NativeImage image;
+            // Download and read the image off-thread
+            try (InputStream input = response.body()) {
+                image = NativeImage.read(input);
+            }
+
+            // Schedule registration on the main render thread
+            NativeImage finalImage = image;
+            Minecraft.getInstance().execute(() -> {
+                String idStr = "remote_" + Integer.toHexString(urlString.hashCode());
+                DynamicTexture dynamicTexture = new DynamicTexture(() -> idStr, finalImage);
+                //dynamicTexture
+                ResourceLocation resourceLocation = ResourceLocation.fromNamespaceAndPath("pvcmappermod", idStr);
+                Minecraft.getInstance().getTextureManager().register(resourceLocation, dynamicTexture);
+                callback.accept(resourceLocation);
+                failedFetches.remove(urlString); // clear cache on success
+            });
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("Bad PNG Signature")) {
+                handleSoftRateLimit(urlString, "Fake Image Header", callback);
+                return;
+            }
+
+            System.err.println("[TextureUtils Error] Exception while fetching URL: " + urlString);
+            Minecraft.getInstance().execute(() -> callback.accept(null));
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Handles Cloudflare "Soft Rate Limits" by applying a backoff and serving a placeholder.
+     */
+    private static void handleSoftRateLimit(String urlString, String reason, Consumer<ResourceLocation> callback) {
+        System.err.println("[TextureUtils] Soft Rate Limit Triggered (" + reason + "): " + urlString);
+        // Back off for 20 seconds for this specific URL
+        failedFetches.put(urlString, System.currentTimeMillis() + 20000);
+        Minecraft.getInstance().execute(() -> callback.accept(blurredTile));
+    }
 }

--- a/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TextureUtils {
     // Limits background tile downloads to prevent Cloudflare rate-limiting.
     // Increased to 16 from 7-8 because the Stagger logic below prevents bursts. Could try higher.
-    private static final int MAX_CONCURRENT_DOWNLOADS = 16;
+    private static final int MAX_CONCURRENT_DOWNLOADS = 20;
     
     // Global stagger to prevent Cloudflare/Origin challenges during initialization's fetches.
     private static final java.util.concurrent.atomic.AtomicLong lastFetchTime = new java.util.concurrent.atomic.AtomicLong(0);


### PR DESCRIPTION
What's all this then
- Updated networking layer to eliminate blocking I/O calls. Replaced openStream + Scanner patterns with newer HttpClient + CompletableFuture.
- Store & map UIs come up much snappier now, 2.2s first-run pause then 0.5s for store search are gone.

Concurrent requests
* The asynced off-thread calls were super fast.
* Introduced a pause and retry stagger to avoid Cloudflare rate-limiting impact. 
* Was hitting the rate limit at 10 concurrent calls, but it was making them back-to-back. Added a 50ms pause between the calls, and started raising the number, up to 20 with no issue. Could try higher.
* When hitting the Cloudflare limit, requests for the tiles would send back a content-type of png, even though it was sending a challenge HTML. I left the code in there that checks for html and checks if it's a 'bad' png. Those logs will tell you if the limit is reached.
* New NetworkUtils.java to centralize the connection pooling and resource reuse.
- used InputStream for the NativeImage, more memory efficient.

Smart request queue
- Went with a Last-In-First-Out queue
- Tiles you're actively viewing load first, off-screen tiles wait their turn
- Switching to nether or panning over to an all-new area on 2K monitor under 3 seconds.
- New function fetchImmediateRemoteTexture for user-facing UI (shops, banners, POIs) to bypass the queue entirely

Tests I did
- F3+2 to see the live FPS graph, - when loading parts of the mod, should not see red spikes when navigating through the UI 
- Open/close full map repeatedly -- should feel instant
- Zoom out on full map with scroll wheel -- tiles should load smoothly, no "Bad PNG" errors
- Switch between nether, terra2, overworld -- same, no errors and loading should be as fast even if there were other tiles loading
- Click POIs with images -- should load in 2-3 seconds
- Search shops, click a sale, map should load quickly -- no freezing

Also of note
- Updated ..gitattributes because I was having trouble with the diffs. The new line will make it 'just work' from now on, is the hope. 
- if not, add `?w=1` to the end of the URL on any compare page to ignore whitespace.
- I altered gradle.properties for just this branch so obvs want to set that back.