### PR TITLE
Fix tab-completion and ctrl-click crashes, and add search auto-focus

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loom_version=1.14-SNAPSHOT
 
 
 # Mod Properties
-mod_version=1.2.2
+mod_version=1.2.3
 maven_group=larrytllama.pvcmappermod
 archives_base_name=pvc-mapper-mod
 

--- a/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
+++ b/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
@@ -260,7 +260,7 @@ public class FullScreenMap extends Screen {
                         mbe.y() > ((shownFeatures[i].z - z) * scale) - (minecraft.font.lineHeight / 2) &&
                         mbe.y() < ((shownFeatures[i].z - z) * scale) + (minecraft.font.lineHeight / 2)) {
                         if(mbe.hasControlDown()) {
-                            minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                            minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                         } else {
                             System.out.println("Feature clicked: " + shownFeatures[i].id);
                             int index = i;
@@ -293,7 +293,7 @@ public class FullScreenMap extends Screen {
                         switch (shownFeatures[i].featureType) {
                             case "place":
                                 if(mbe.hasControlDown()) {
-                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                                 } else {
                                     pfu.fetchPlaceAsync(shownFeatures[index].id)
                                         .thenAccept(feature -> {
@@ -317,7 +317,7 @@ public class FullScreenMap extends Screen {
 
                             case "portal":
                                 if(mbe.hasControlDown()) {
-                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", pfu.getPortalPrettyName(shownFeatures[i].type), shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", pfu.getPortalPrettyName(shownFeatures[i].type), (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                                 }
                                 break;
                             default:

--- a/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
+++ b/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
@@ -141,6 +141,9 @@ public class ShopsScreen extends Screen {
                     Component.literal(banner.description));
             sponsorURLString = banner.link;
         });
+
+        this.setInitialFocus(itemSearch);
+        this.setFocused(itemSearch);
     }
 
     @Override
@@ -150,7 +153,9 @@ public class ShopsScreen extends Screen {
             else Minecraft.getInstance().setScreen(null);
         } else if(itemSearch.isFocused()) {
             if(keyEvent.key() == GLFW.GLFW_KEY_TAB) {
-                itemSearch.setValue(filteredItems[0]);
+                if (filteredItems != null && filteredItems.length > 0 && filteredItems[0] != null) {
+                    itemSearch.setValue(filteredItems[0]);
+                }
             } else if(keyEvent.key() == GLFW.GLFW_KEY_ENTER) {
                 if(currentSearchMode.equals("item")) this.openWithItem(this.itemSearch.getValue());
                 else if(currentSearchMode.equals("username")) this.openWithUsername(this.itemSearch.getValue());


### PR DESCRIPTION
Made fixes to #24  and #23, plus I added a feature to auto-focus the search bar. And did a version bump to 1.2.3, which might be presumptuous.

### Changes

* **Issue #23 (Tab shop screen crash):** 
  * Fixed an `ArrayIndexOutOfBoundsException` that showed when user presses _Tab_ on the shop search screen while the filtered list of items was empty/uninitialized.
  * Added checks to ensure that it doesn't access an empty array.
* **Issue #24 (Ctrl-click map coordinates crash):** 
  * Fixed an `IllegalFormatConversionException` (`d != java.lang.Float`) when a user control-clicked something on the fullscreen map, which I realized was used to paste their coordinates in chat.
  * Cast the coordinates to `(int)` before passing them to the `%d` if you know what I mean.
* **Shop screen: search auto-focus:**
  * When the shop screen loads, now it auto-focuses on the search input so user doesn't have to hit Tab first.
  * Noticed the search box wouldn't receive characters without a mouse click, solved by explicitly setting `this.setFocused(itemSearch)` on the parent `Screen`.