### PR TITLE
refactor: optimize memory, add structured logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loom_version=1.14-SNAPSHOT
 
 
 # Mod Properties
-mod_version=1.2.2
+mod_version=1.2.3
 maven_group=larrytllama.pvcmappermod
 archives_base_name=pvc-mapper-mod
 

--- a/src/client/java/larrytllama/pvcmappermod/ClothConfigScreen.java
+++ b/src/client/java/larrytllama/pvcmappermod/ClothConfigScreen.java
@@ -32,6 +32,7 @@ public class ClothConfigScreen extends Screen {
     private BooleanListEntry checkForUpdates;
     private BooleanListEntry useDarkTiles;
     private BooleanListEntry collectData;
+    private BooleanListEntry debugMode;
     private StringListEntry mapTileSource;
     private IntegerSliderEntry miniMapZoom;
     private LongSliderEntry minimapScale;
@@ -51,6 +52,7 @@ public class ClothConfigScreen extends Screen {
             sp.checkForUpdates = this.checkForUpdates.getValue();
             sp.minimapScale = this.minimapScale.getValue() / 100.0;
             sp.collectData = this.collectData.getValue();
+            sp.debugMode = this.debugMode.getValue();
             sp.saveSettings();
         })
         .setTitle(Component.literal("PVC Mapper Mod Settings"));
@@ -80,7 +82,7 @@ public class ClothConfigScreen extends Screen {
 
         ConfigCategory miscSettings = builder.getOrCreateCategory(Component.literal("Miscellaneous Settings"));
         this.mapTileSource = entryBuilder.startTextField(Component.literal("Tile Source"), sp.mapTileSource)
-            .setDefaultValue("https://pvc.coolwebsite.uk/maps/") 
+            .setDefaultValue(NetworkUtils.BASE_URL + "/maps/") 
             .setTooltip(Component.literal("Where the PVC Mapper Mod should get its background tiles from."), Component.literal("Important! Your URL must include the / at the end!").withStyle(ChatFormatting.RED), Component.literal("If the default isn't working, try: https://web.peacefulvanilla.club/maps/tiles/"))
             .build();
         miscSettings.addEntry(this.mapTileSource);
@@ -104,6 +106,13 @@ public class ClothConfigScreen extends Screen {
             .setTooltip(Component.literal("Contribute to the PVC Mapper, uploading ranks and player nicknames!"), Component.literal("(The mod simply uploads the entries provided by the tab list)"))
             .build();
         miscSettings.addEntry(this.collectData);
+        
+        this.debugMode = entryBuilder.startBooleanToggle(Component.literal("Debug Mode"), sp.debugMode)
+            .setDefaultValue(false)
+            .setTooltip(Component.literal("Adds extra logging in the console."))
+            .build();
+        miscSettings.addEntry(this.debugMode);
+        
         miscSettings.addEntry(
             entryBuilder.startTextDescription(Component.literal("To change keybinds, head to Options > Controls > Keybinds and scroll down!")).build()
         );

--- a/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
+++ b/src/client/java/larrytllama/pvcmappermod/FullScreenMap.java
@@ -100,7 +100,7 @@ public class FullScreenMap extends Screen {
     private int topLeftX = 0;
     private int topLeftZ = 0;
     public int zoomlevel = 8;
-    public int maxZoomLevel = 8;
+    public int maxZoomLevel = 9;
     public int minZoomLevel = 1;
 
     public int x = 0;
@@ -122,6 +122,8 @@ public class FullScreenMap extends Screen {
 
     // On mouse move, we'll check for new tiles
     private void onMouseMove(int mouseX, int mouseY) {
+        int renderZoom = Math.min(8, zoomlevel);
+        int renderTileSize = 1 << (17 - renderZoom);
         int tilesize = 1 << (17 - zoomlevel);
         double scale = (double) minimapTileSize / tilesize;
         double worldLeft = x;
@@ -130,30 +132,23 @@ public class FullScreenMap extends Screen {
         double worldBottom = z + (this.height / scale);
         String dimension = "" + currentDimension;
         // Figure out tile no. at top left/bottom right
-        int topLeftTileX = Math.floorDiv((int) worldLeft, tilesize) - 1;
-        int topLeftTileZ = Math.floorDiv((int) worldTop, tilesize) - 1;
-        int bottomRightTileX = Math.floorDiv((int) worldRight, tilesize) + 1;
-        int bottomRightTileZ = Math.floorDiv((int) worldBottom, tilesize) + 1;
+        int topLeftTileX = Math.floorDiv((int) worldLeft, renderTileSize) - 1;
+        int topLeftTileZ = Math.floorDiv((int) worldTop, renderTileSize) - 1;
+        int bottomRightTileX = Math.floorDiv((int) worldRight, renderTileSize) + 1;
+        int bottomRightTileZ = Math.floorDiv((int) worldBottom, renderTileSize) + 1;
 
         int thisZoomLevel = zoomlevel;
         for (int iX = topLeftTileX; iX < bottomRightTileX; iX++) {
             if(thisZoomLevel != zoomlevel && !currentDimension.equals(dimension)) break;
             for (int iZ = topLeftTileZ; iZ < bottomRightTileZ; iZ++) {
                 if(thisZoomLevel != zoomlevel && !currentDimension.equals(dimension)) break;
-                ResourceLocation tile = tiles.get(String.format("%s/%d/%d_%d", dimension, thisZoomLevel, iX, iZ));
-                if (tile == null) {
-                    final int tileX = iX;
-                    final int tileZ = iZ;
-                    // Temporarily set to a blurred tile to stop the repeating null
-                    tiles.put(String.format("%s/%d/%d_%d", dimension, thisZoomLevel, tileX, tileZ), blurredTile);
-                    // Make a request for the tile
-                    String thisDimension = dimension.equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : dimension;
-                    String url = String.format("%s%s/%d/%d_%d.png",
-                        sp.mapTileSource, thisDimension, zoomlevel, iX, iZ);
-                    TextureUtils.fetchRemoteTexture(url, (id) -> {
-                        tiles.put(String.format("%s/%d/%d_%d", dimension, thisZoomLevel, tileX, tileZ), id);
-                    });
-                }
+                
+                String thisDimension = dimension.equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : dimension;
+                String url = String.format("%s%s/%d/%d_%d.png",
+                    sp.mapTileSource, thisDimension, renderZoom, iX, iZ);
+                
+                // Rely on TextureUtils to manage the cache and deduplicate pending fetches
+                TextureUtils.fetchRemoteTexture(url, (id) -> {});
             }
         }
     }
@@ -181,7 +176,7 @@ public class FullScreenMap extends Screen {
                 shownClaims = new ArrayList<ClaimMarkers>();
                 return;
             }
-            System.out.println("Checkbox selected! Finding claims...");
+            LogUtils.debug("Checkbox selected! Finding claims...");
             shownClaims = pfu.getClaimsInBounds(currentDimension, x, (int) (x + (this.width / scale)), z,
                     (int) (z + ((this.height - bottomMapOffset) / scale)));
         } else {
@@ -251,7 +246,7 @@ public class FullScreenMap extends Screen {
             // Check to see if a thing has been clicked
             for (int i = 0; i < shownFeatures.length; i++) {
                 if(shownFeatures[i].id == 1) {
-                    System.out.println("X/Z: " + ((shownFeatures[i].x - x) * scale) + " / " + ((shownFeatures[i].z - z) * scale));
+                    LogUtils.debug("X/Z: " + ((shownFeatures[i].x - x) * scale) + " / " + ((shownFeatures[i].z - z) * scale));
                 }
                 if(shownFeatures[i].featureType.equals("area")) {
                     int itemWidth = minecraft.font.width(shownFeatures[i].name);
@@ -260,9 +255,9 @@ public class FullScreenMap extends Screen {
                         mbe.y() > ((shownFeatures[i].z - z) * scale) - (minecraft.font.lineHeight / 2) &&
                         mbe.y() < ((shownFeatures[i].z - z) * scale) + (minecraft.font.lineHeight / 2)) {
                         if(mbe.hasControlDown()) {
-                            minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                            minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                         } else {
-                            System.out.println("Feature clicked: " + shownFeatures[i].id);
+                            LogUtils.debug("Feature clicked: " + shownFeatures[i].id);
                             int index = i;
                             pfu.fetchAreaAsync(shownFeatures[index].id)
                                 .thenAccept(feature -> {
@@ -293,7 +288,7 @@ public class FullScreenMap extends Screen {
                         switch (shownFeatures[i].featureType) {
                             case "place":
                                 if(mbe.hasControlDown()) {
-                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", shownFeatures[i].name, (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                                 } else {
                                     pfu.fetchPlaceAsync(shownFeatures[index].id)
                                         .thenAccept(feature -> {
@@ -317,7 +312,7 @@ public class FullScreenMap extends Screen {
 
                             case "portal":
                                 if(mbe.hasControlDown()) {
-                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", pfu.getPortalPrettyName(shownFeatures[i].type), shownFeatures[i].x, shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
+                                    minecraft.setScreen(new ChatScreen(String.format("%s: %d, %d in %s", pfu.getPortalPrettyName(shownFeatures[i].type), (int) shownFeatures[i].x, (int) shownFeatures[i].z, pfu.prettyDimensionName(currentDimension)), false));
                                 }
                                 break;
                             default:
@@ -650,10 +645,14 @@ public class FullScreenMap extends Screen {
                         context.drawCenteredString(minecraft.font, overlayImageStatus, (((this.width / 2) - 10 - (this.width / 6)) / 2) + (this.width / 6), 121, 0xFFFFFFFF);
                     }
                 } catch(Exception e) {
-                    System.out.println("[PVC Mapper Mod] Unable to write area details to screen renderererer.");
+                    LogUtils.debug("[PVC Mapper Mod] Unable to write area details to screen renderererer.");
                 }
             }
         } else {
+            int renderZoom = Math.min(8, zoomlevel);
+            int renderTileSize = 1 << (17 - renderZoom);
+            int drawSize = minimapTileSize * (1 << (zoomlevel - renderZoom));
+            
             int tilesize = 1 << (17 - zoomlevel);
             double scale = (double) minimapTileSize / tilesize;
             double worldLeft = x;
@@ -662,34 +661,36 @@ public class FullScreenMap extends Screen {
             double worldBottom = z + ((this.height - bottomMapOffset) / scale);
 
             // Figure out tile no. at top left/bottom right
-            int topLeftTileX = Math.floorDiv((int) worldLeft, tilesize);
-            int topLeftTileZ = Math.floorDiv((int) worldTop, tilesize);
-            int bottomRightTileX = Math.floorDiv((int) worldRight, tilesize) + 1;
-            int bottomRightTileZ = Math.floorDiv((int) worldBottom, tilesize) + 1;
+            int topLeftTileX = Math.floorDiv((int) worldLeft, renderTileSize);
+            int topLeftTileZ = Math.floorDiv((int) worldTop, renderTileSize);
+            int bottomRightTileX = Math.floorDiv((int) worldRight, renderTileSize) + 1;
+            int bottomRightTileZ = Math.floorDiv((int) worldBottom, renderTileSize) + 1;
 
             // Iterate thru visible tiles
-            double xOffsetFromTileStart = Math.floorMod((int) worldLeft, tilesize);
-            double zOffsetFromTileStart = Math.floorMod((int) worldTop, tilesize);
+            double xOffsetFromTileStart = Math.floorMod((int) worldLeft, renderTileSize);
+            double zOffsetFromTileStart = Math.floorMod((int) worldTop, renderTileSize);
             context.scissorStack.push(new ScreenRectangle(0, 0, this.width, this.height - bottomMapOffset));
             for (int iX = topLeftTileX; iX < bottomRightTileX; iX++) {
                 for (int iZ = topLeftTileZ; iZ < bottomRightTileZ; iZ++) {
-                    ResourceLocation tile = tiles.get(String.format("%s/%d/%d_%d", currentDimension, zoomlevel, iX, iZ));
+                    String thisDimension = currentDimension.equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : currentDimension;
+                    String url = String.format("%s%s/%d/%d_%d.png", sp.mapTileSource, thisDimension, renderZoom, iX, iZ);
+                    ResourceLocation tile = TextureUtils.getCachedTexture(url);
                     if (tile == null)
-                        continue;
+                        tile = TextureUtils.blurredTile;
                     context.pose().pushMatrix();
                     context.pose().translate(
                             (float) ((topLeftX - (xOffsetFromTileStart * scale)) + // The top left GUI pos - how far
                                                                                    // from the start of the tile
-                                    ((iX - topLeftTileX) * minimapTileSize)), // + How many tiles along we are
+                                    ((iX - topLeftTileX) * drawSize)), // + How many tiles along we are
                             (float) ((topLeftZ - (zOffsetFromTileStart * scale)) + // All the same
-                                    ((iZ - topLeftTileZ) * minimapTileSize)) // For the Z axis
+                                    ((iZ - topLeftTileZ) * drawSize)) // For the Z axis
                     );
                     context.blit(
                             RenderPipelines.GUI_TEXTURED, tile, // Render tile with the following x pos:
                             0, 0,
                             0, 0, // u/v
-                            minimapTileSize, minimapTileSize, // width/height
-                            minimapTileSize, minimapTileSize // texturewidth/textureheight
+                            drawSize, drawSize, // width/height
+                            drawSize, drawSize // texturewidth/textureheight
                     );
                     context.pose().popMatrix();
                 }

--- a/src/client/java/larrytllama/pvcmappermod/LogUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/LogUtils.java
@@ -1,0 +1,58 @@
+package larrytllama.pvcmappermod;
+
+public class LogUtils {
+    public static void info(Object msg) {
+        System.out.println("[INFO] " + msg);
+    }
+
+    public static void info(String format, Object... args) {
+        System.out.println("[INFO] " + String.format(format, args));
+    }
+
+    public static void warn(Object msg) {
+        System.out.println("[WARN] " + msg);
+    }
+
+    public static void warn(String format, Object... args) {
+        System.out.println("[WARN] " + String.format(format, args));
+    }
+
+    public static void warn(String msg, Throwable e) {
+        System.out.println("[WARN] " + msg);
+        e.printStackTrace();
+    }
+
+    public static void error(Object msg) {
+        System.err.println("[ERROR] " + msg);
+    }
+
+    public static void error(String msg, Throwable e) {
+        System.err.println("[ERROR] " + msg);
+        e.printStackTrace();
+    }
+
+    public static void error(String format, Object... args) {
+        System.err.println("[ERROR] " + String.format(format, args));
+    }
+
+    public static void debug(Object msg) {
+        SettingsProvider sp = SettingsProvider.getInstance();
+        if (sp != null && sp.debugMode) {
+            System.out.println("[DEBUG] " + msg);
+        }
+    }
+
+    public static void debug(String msg) {
+        SettingsProvider sp = SettingsProvider.getInstance();
+        if (sp != null && sp.debugMode) {
+            System.out.println("[DEBUG] " + msg);
+        }
+    }
+
+    public static void debug(String format, Object... args) {
+        SettingsProvider sp = SettingsProvider.getInstance();
+        if (sp != null && sp.debugMode) {
+            System.out.println("[DEBUG] " + String.format(format, args));
+        }
+    }
+}

--- a/src/client/java/larrytllama/pvcmappermod/MapperCmdHandler.java
+++ b/src/client/java/larrytllama/pvcmappermod/MapperCmdHandler.java
@@ -2,7 +2,6 @@ package larrytllama.pvcmappermod;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -149,8 +148,8 @@ public class MapperCmdHandler {
                     return 1;
                 }))
                 .then(ClientCommandManager.literal("clearcache").executes((context) -> {
-                    // Reset image cache
-                    modclient.minimap.textureLocations = new ResourceLocation[4];
+                    // Reset minimap image state
+                    modclient.minimap.textureUrls = new String[4];
                     // Including this one which should never realistically be a value
                     // (Unless PVC's still expanding the map 15000 years later)
                     modclient.minimap.tileCoords = new int[][] {
@@ -159,8 +158,8 @@ public class MapperCmdHandler {
                         { Integer.MIN_VALUE, Integer.MIN_VALUE },
                         { Integer.MIN_VALUE, Integer.MIN_VALUE }
                     };
-                    // And reset the full map menu tiles too :D
-                    modclient.fsm.tiles = new HashMap<String, ResourceLocation>();
+                    // Reset the central global tile cache in TextureUtils
+                    TextureUtils.clearCache();
 
                     context.getSource().sendFeedback(Component.literal("Successfully cleared map tile cache (yay!)"));
                     return 1;

--- a/src/client/java/larrytllama/pvcmappermod/Minimap.java
+++ b/src/client/java/larrytllama/pvcmappermod/Minimap.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Scanner;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -150,7 +149,7 @@ public class Minimap {
     }
 
     // Image cache
-    public ResourceLocation[] textureLocations = new ResourceLocation[4]; // Each x/y.
+    public String[] textureUrls = new String[4]; // Each x/y.
     public int[][] tileCoords = new int[4][2]; // Each x/y, each tile coord pair.
     
     // Zoom level for map
@@ -278,7 +277,7 @@ public class Minimap {
         } else if(sp.miniMapPos == MiniMapPositions.TOP_LEFT) {
             tooltipX = 100;
         } else {
-            System.out.println("Whoops no minimap pos: " + sp.miniMapPos);
+            LogUtils.debug("Whoops no minimap pos: " + sp.miniMapPos);
         }
         TooltipRenderUtil.renderTooltipBackground(
                 context,
@@ -304,7 +303,7 @@ public class Minimap {
 
     public void resetTileImageCache() {
         // Reset image cache
-        textureLocations = new ResourceLocation[4];
+        textureUrls = new String[4];
         // Including this one which should never realistically be a value
         // (Unless PVC's still expanding the map 15000 years later)
         tileCoords = new int[][] {
@@ -398,7 +397,7 @@ public class Minimap {
         if(!this.lastDimension.equals(getDimensionNID())) {
             this.lastDimension = getDimensionNID();
             // Reset image cache
-            textureLocations = new ResourceLocation[4];
+            textureUrls = new String[4];
             // Including this one which should never realistically be a value
             // (Unless PVC's still expanding the map 15000 years later)
             tileCoords = new int[][] {
@@ -413,29 +412,23 @@ public class Minimap {
         double x = mc.player.getX();
         double z = mc.player.getZ();
         // Calculate tile size from zoom
+        int renderZoom = Math.min(8, zoomlevel);
+        int renderTileSize = 1 << (17 - renderZoom);
+        int drawSize = minimapTileSize * (1 << (zoomlevel - renderZoom));
         int tilesize = 1 << (17 - zoomlevel);
         // Make sure negative tiles start at -1 not -0
         // -256 to work with our 2x2 grid moving minimap
-        int divX = Math.floorDiv((int) (x) - 256, tilesize);
-        int divZ = Math.floorDiv((int) (z) - 256, tilesize);
+        int divX = Math.floorDiv((int) (x) - 256, renderTileSize);
+        int divZ = Math.floorDiv((int) (z) - 256, renderTileSize);
         if (tileCoords[0][0] != divX || tileCoords[0][1] != divZ) {
-            ResourceLocation[] tempArr = textureLocations.clone();
             // Save ourselves requesting content we already have.
             int newArrayIndex = 0;
             for (int i2 = divZ; i2 < divZ + 2; i2++) {
                 for (int i = divX; i < divX + 2; i++) {
-                    int arrayIndex = arrHasSubArr(tileCoords, i, i2);
-                    if (arrayIndex != -1) {
-                        textureLocations[newArrayIndex] = tempArr[arrayIndex];
-                    } else {
-                        int indexToSet = newArrayIndex;
-                        String thisDimension = getDimensionNID().equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : getDimensionNID();
-                        String url = String.format("%s%s/%d/%d_%d.png",
-                            sp.mapTileSource, thisDimension, zoomlevel, i, i2);
-                        TextureUtils.fetchImmediateRemoteTexture(url, (id) -> {
-                            textureLocations[indexToSet] = id;
-                        });
-                    }
+                    String thisDimension = getDimensionNID().equals("minecraft_terra2") && sp.useDarkTiles ? "minecraft_terra2_night" : getDimensionNID();
+                    String url = String.format("%s%s/%d/%d_%d.png",
+                        sp.mapTileSource, thisDimension, renderZoom, i, i2);
+                    textureUrls[newArrayIndex] = url;
                     newArrayIndex += 1;
                 }
             }
@@ -449,13 +442,13 @@ public class Minimap {
             tileCoords[3][1] = divZ + 1;
 
             // Add places in too
-            int minx = tileCoords[0][0] * tilesize;
-            int maxx = (tileCoords[3][0] * tilesize) + tilesize;
-            int minz = tileCoords[0][1] * tilesize;
-            int maxz = (tileCoords[3][1] * tilesize) + tilesize;
+            int minx = tileCoords[0][0] * renderTileSize;
+            int maxx = (tileCoords[3][0] * renderTileSize) + renderTileSize;
+            int minz = tileCoords[0][1] * renderTileSize;
+            int maxz = (tileCoords[3][1] * renderTileSize) + renderTileSize;
             try {
                 java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                    .uri(new URI(String.format("https://pvc.coolwebsite.uk/api/v1/fetch/places/%s/%d/%d/%d/%d",
+                    .uri(new URI(String.format("%s/fetch/places/%s/%d/%d/%d/%d", NetworkUtils.API_V1,
                         getDimensionNID(), minx, maxx, minz, maxz)))
                     .GET().build();
                 NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
@@ -464,17 +457,15 @@ public class Minimap {
                             Gson gson = new Gson();
                             placesList = new ArrayList<PlaceFetch>(Arrays.asList(gson.fromJson(response.body(), PlaceFetch[].class)));
                         } else {
-                            System.out.println("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
+                            LogUtils.error("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
                         }
                     })
                     .exceptionally(e -> {
-                        System.out.println("Failed to fetch places from PVC Mapper!");
-                        System.out.println(e);
+                        LogUtils.error("Failed to fetch places from PVC Mapper!", e);
                         return null;
                     });
             } catch (Exception e) {
-                System.out.println("Failed to fetch places from PVC Mapper!");
-                System.out.println(e);
+                LogUtils.error("Failed to fetch places from PVC Mapper!", e);
             }
 
             hasNotBeenInitialisedYet = false;
@@ -486,11 +477,11 @@ public class Minimap {
         
         double scale = (double) minimapTileSize / tilesize;
 
-        double tileX = Math.floorDiv((long) x, tilesize);
-        double tileZ = Math.floorDiv((long) z, tilesize);
+        double tileX = Math.floorDiv((long) x, renderTileSize);
+        double tileZ = Math.floorDiv((long) z, renderTileSize);
 
-        double localX = Math.floorMod((long) x, tilesize);
-        double localZ = Math.floorMod((long) z, tilesize);
+        double localX = Math.floorMod((long) x, renderTileSize);
+        double localZ = Math.floorMod((long) z, renderTileSize);
 
         double offsetX = localX * scale;
         double offsetZ = localZ * scale;
@@ -500,44 +491,64 @@ public class Minimap {
 
         context.enableScissor(topLeftX, topLeftZ, topLeftX + minimapTileSize, topLeftZ + minimapTileSize);
         // Draw each tile to be visible
-        if (textureLocations[0] != null) {
+        if (textureUrls[0] != null) {
             // If I'm stood at 0, 0 this tile will be -1_-1.png and be at topLeftX-40,
             // topLeftZ-40
             // If I'm stood at 256, 256 this tile will be 0_0.png and be at topLeftX-0,
             // topLeftZ-0
-            double drawX = (divX + 0 - tileX) * minimapTileSize - viewX;
-            double drawZ = (divZ + 0 - tileZ) * minimapTileSize - viewZ;
+            ResourceLocation tex = TextureUtils.getCachedTexture(textureUrls[0]);
+            if (tex == null) {
+                TextureUtils.fetchImmediateRemoteTexture(textureUrls[0], (id) -> {});
+                tex = TextureUtils.blurredTile;
+            }
+            double drawX = (divX + 0 - tileX) * drawSize - viewX;
+            double drawZ = (divZ + 0 - tileZ) * drawSize - viewZ;
             context.pose().pushMatrix();
             context.pose().translate((float) (topLeftX + drawX), (float) (topLeftZ + drawZ));
-            context.blit(RenderPipelines.GUI_TEXTURED, textureLocations[0], 0, 0, 0, 0, minimapTileSize,
-                    minimapTileSize, minimapTileSize, minimapTileSize);
+            context.blit(RenderPipelines.GUI_TEXTURED, tex, 0, 0, 0, 0, drawSize,
+                    drawSize, drawSize, drawSize);
             context.pose().popMatrix();
         }
-        if (textureLocations[1] != null) {
-            double drawX = (divX + 1 - tileX) * minimapTileSize - viewX;
-            double drawZ = (divZ + 0 - tileZ) * minimapTileSize - viewZ;
+        if (textureUrls[1] != null) {
+            ResourceLocation tex = TextureUtils.getCachedTexture(textureUrls[1]);
+            if (tex == null) {
+                TextureUtils.fetchImmediateRemoteTexture(textureUrls[1], (id) -> {});
+                tex = TextureUtils.blurredTile;
+            }
+            double drawX = (divX + 1 - tileX) * drawSize - viewX;
+            double drawZ = (divZ + 0 - tileZ) * drawSize - viewZ;
             context.pose().pushMatrix();
             context.pose().translate((float) (topLeftX + drawX), (float) (topLeftZ + drawZ));
-            context.blit(RenderPipelines.GUI_TEXTURED, textureLocations[1], 0, 0, 0, 0, minimapTileSize,
-                    minimapTileSize, minimapTileSize, minimapTileSize);
+            context.blit(RenderPipelines.GUI_TEXTURED, tex, 0, 0, 0, 0, drawSize,
+                    drawSize, drawSize, drawSize);
             context.pose().popMatrix();
         }
-        if (textureLocations[2] != null) {
-            double drawX = (divX + 0 - tileX) * minimapTileSize - viewX;
-            double drawZ = (divZ + 1 - tileZ) * minimapTileSize - viewZ;
+        if (textureUrls[2] != null) {
+            ResourceLocation tex = TextureUtils.getCachedTexture(textureUrls[2]);
+            if (tex == null) {
+                TextureUtils.fetchImmediateRemoteTexture(textureUrls[2], (id) -> {});
+                tex = TextureUtils.blurredTile;
+            }
+            double drawX = (divX + 0 - tileX) * drawSize - viewX;
+            double drawZ = (divZ + 1 - tileZ) * drawSize - viewZ;
             context.pose().pushMatrix();
             context.pose().translate((float) (topLeftX + drawX), (float) (topLeftZ + drawZ));
-            context.blit(RenderPipelines.GUI_TEXTURED, textureLocations[2], 0, 0, 0, 0, minimapTileSize,
-                    minimapTileSize, minimapTileSize, minimapTileSize);
+            context.blit(RenderPipelines.GUI_TEXTURED, tex, 0, 0, 0, 0, drawSize,
+                    drawSize, drawSize, drawSize);
             context.pose().popMatrix();
         }
-        if (textureLocations[3] != null) {
-            double drawX = (divX + 1 - tileX) * minimapTileSize - viewX;
-            double drawZ = (divZ + 1 - tileZ) * minimapTileSize - viewZ;
+        if (textureUrls[3] != null) {
+            ResourceLocation tex = TextureUtils.getCachedTexture(textureUrls[3]);
+            if (tex == null) {
+                TextureUtils.fetchImmediateRemoteTexture(textureUrls[3], (id) -> {});
+                tex = TextureUtils.blurredTile;
+            }
+            double drawX = (divX + 1 - tileX) * drawSize - viewX;
+            double drawZ = (divZ + 1 - tileZ) * drawSize - viewZ;
             context.pose().pushMatrix();
             context.pose().translate((float) (topLeftX + drawX), (float) (topLeftZ + drawZ));
-            context.blit(RenderPipelines.GUI_TEXTURED, textureLocations[3], 0, 0, 0, 0, minimapTileSize,
-                    minimapTileSize, minimapTileSize, minimapTileSize);
+            context.blit(RenderPipelines.GUI_TEXTURED, tex, 0, 0, 0, 0, drawSize,
+                    drawSize, drawSize, drawSize);
             context.pose().popMatrix();
         }
         context.disableScissor();

--- a/src/client/java/larrytllama/pvcmappermod/NetworkUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/NetworkUtils.java
@@ -13,4 +13,9 @@ public class NetworkUtils {
             .connectTimeout(Duration.ofSeconds(10))
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
+
+    // API Endpoints
+    public static final String BASE_URL = "https://pvc.coolwebsite.uk";
+    public static final String API_V1 = BASE_URL + "/api/v1";
+    public static final String API_V2 = BASE_URL + "/api/v2";
 }

--- a/src/client/java/larrytllama/pvcmappermod/PVCMapperModClient.java
+++ b/src/client/java/larrytllama/pvcmappermod/PVCMapperModClient.java
@@ -56,6 +56,8 @@ public class PVCMapperModClient implements ClientModInitializer {
     public void onInitializeClient() {
         // Settings provider
         SettingsProvider sp = SettingsProvider.getInstance();
+        sp.updateSettings();
+        
         // Set up player fetchererer
         PlayerFetchUtils pfu = new PlayerFetchUtils();
         new MapperCmdHandler(pfu, this);
@@ -104,7 +106,7 @@ public class PVCMapperModClient implements ClientModInitializer {
                     //   C) You're mean :(
                     // So, eh, please don't. Thanks <3
                     HttpRequest req = HttpRequest.newBuilder()
-                        .uri(URI.create("https://pvc.coolwebsite.uk/api/v2/rank-upload/setPlayerRanks?me=" + Minecraft.getInstance().player.getGameProfile().name()))
+                        .uri(URI.create(NetworkUtils.API_V2 + "/rank-upload/setPlayerRanks?me=" + Minecraft.getInstance().player.getGameProfile().name()))
                         .POST(HttpRequest.BodyPublishers.ofString(jsonString))
                         .header("Content-Type", "application/json")
                         .build();
@@ -113,8 +115,7 @@ public class PVCMapperModClient implements ClientModInitializer {
                     } catch(Exception e) {
                         // No bother, we'll just log to console and ignore!
                         // Who actually cares about HTTP error codes? Nothing wrong with ignoring them! *foreshadowing*
-                        System.out.println("[PVC Mapper Mod] Oh naur! Uploading data to mapper failed. Here's the error:");
-                        System.out.println(e);
+                        LogUtils.error("[PVC Mapper Mod] Oh naur! Uploading data to mapper failed. Here's the error:", e);
                     }
                 });
             }

--- a/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/PlayerFetchUtils.java
@@ -68,7 +68,7 @@ public class PlayerFetchUtils {
                     }
                     try {
                         java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                            .uri(new URI("https://pvc.coolwebsite.uk/api/v1/players"))
+                            .uri(new URI(NetworkUtils.API_V1 + "/players"))
                             .GET().build();
                         NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                             .thenAccept(response -> {
@@ -79,7 +79,7 @@ public class PlayerFetchUtils {
                                     errorCount = 0;
                                 } else {
                                     errorCount += 1;
-                                    System.out.println("Failed to fetch players from PVC Mapper! Code: " + response.statusCode());
+                                    LogUtils.error("Failed to fetch players from PVC Mapper! Code: " + response.statusCode());
                                     if(errorCount == 3) { // Avoid toast-spam
                                         showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Run /mapper retryupdates To try again.");
                                         stopUpdates();
@@ -92,16 +92,14 @@ public class PlayerFetchUtils {
                                     showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Run /mapper retryupdates To try again.");
                                     stopUpdates();
                                 }
-                                System.out.println("Failed to fetch players from PVC Mapper!");
-                                System.out.println(e);
+                                LogUtils.error("Failed to fetch players from PVC Mapper!", e);
                                 return null;
                             });
                     } catch (Exception e) {
                         errorCount += 1;
                         showToast("PVC Mapper Error", "Couldn't connect to PVC Mapper. Run /mapper retryupdates To try again.");
                         stopUpdates();
-                        System.out.println("Failed to fetch players from PVC Mapper!");
-                        System.out.println(e);
+                        LogUtils.error("Failed to fetch players from PVC Mapper!", e);
                     }
                 },
                 0,
@@ -158,12 +156,12 @@ public class PlayerFetchUtils {
                         }
                     }
                 } else {
-                    System.out.println("Unknown claim type: " + claimsList.markers[i].type);
+                    LogUtils.warn("Unknown claim type: " + claimsList.markers[i].type);
                 }
             }
         } else if(dimension.equals("minecraft_the_nether")) {
             if (netherClaimsList == null) { 
-                System.out.println("No nether claims! :O");
+                LogUtils.debug("No nether claims! :O");
                 return claimsInBounds;
             }
             for (int i = 0; i < netherClaimsList.markers.length; i++) {
@@ -191,11 +189,11 @@ public class PlayerFetchUtils {
                         }
                     }
                 } else {
-                    System.out.println("Unknown claim type: " + netherClaimsList.markers[i].type);
+                    LogUtils.warn("Unknown claim type: " + netherClaimsList.markers[i].type);
                 }
             }
         } else {
-            System.out.println("Unknown claimed dimension: " + dimension);
+            LogUtils.warn("Unknown claimed dimension: " + dimension);
         }
         return claimsInBounds;
     }
@@ -216,11 +214,11 @@ public class PlayerFetchUtils {
     }
 
     public void fetchClaims() {
-        System.out.println("Fetching claims from https://pvc.coolwebsite.uk/api/v1/claims");
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/claims"))
+                .uri(new URI(NetworkUtils.API_V1 + "/claims"))
                 .GET().build();
+            LogUtils.debug("Fetching claims from " + request.uri().toString());
             NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenAccept(response -> {
                     if (response.statusCode() == 200) {
@@ -229,25 +227,24 @@ public class PlayerFetchUtils {
                                 .create();
                         claimsList = gson.fromJson(response.body(), ClaimFetch.class);
                     } else {
-                        System.out.println("Failed to fetch claims from PVC Mapper! Code: " + response.statusCode());
+                        LogUtils.error("Failed to fetch claims from PVC Mapper! Code: " + response.statusCode());
                     }
                 })
                 .exceptionally(e -> {
-                    System.out.println("Failed to fetch claims from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch claims from PVC Mapper!", e);
                     return null;
                 });
         } catch (Exception e) {
             //showToast("Mapper Connect Error", "Check your internet connection?");
-            System.out.println("Failed to fetch claims from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch claims from PVC Mapper!", e);
         }
 
         // Get nether claims too!
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/claims/nether"))
+                .uri(new URI(NetworkUtils.API_V1 + "/claims/nether"))
                 .GET().build();
+            LogUtils.debug("Fetching nether claims from " + request.uri().toString());
             NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenAccept(response -> {
                     if (response.statusCode() == 200) {
@@ -256,27 +253,25 @@ public class PlayerFetchUtils {
                                 .create();
                         netherClaimsList = gson.fromJson(response.body(), ClaimFetch.class);
                     } else {
-                        System.out.println("Failed to fetch nether claims from PVC Mapper! Code: " + response.statusCode());
+                        LogUtils.error("Failed to fetch nether claims from PVC Mapper! Code: " + response.statusCode());
                     }
                 })
                 .exceptionally(e -> {
-                    System.out.println("Failed to fetch nether claims from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch nether claims from PVC Mapper!", e);
                     return null;
                 });
         } catch (Exception e) {
-            System.out.println("Failed to fetch nether claims from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch nether claims from PVC Mapper!", e);
         }
     }
 
     public CompletableFuture<FeatureFetch[]> fetchFeaturesAsync(String dimension, int x1, int x2, int z1, int z2) {
-        String url = String.format("https://pvc.coolwebsite.uk/api/v2/fetch/things/%s/%d/%d/%d/%d", dimension, x1, x2, z1, z2);
-        System.out.println("Fetching all features in area from PVC Mapper.");
+        String url = String.format("%s/fetch/things/%s/%d/%d/%d/%d", NetworkUtils.API_V2, dimension, x1, x2, z1, z2);
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
                 .uri(new URI(url))
                 .GET().build();
+            LogUtils.debug("Fetching all features in area from: " + request.uri().toString());
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     if (response.statusCode() == 200) {
@@ -288,14 +283,12 @@ public class PlayerFetchUtils {
                 })
                 .exceptionally(e -> {
                     showToast("Mapper Connect Error", "Check your internet connection?");
-                    System.out.println("Failed to fetch features from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch features from PVC Mapper!", e);
                     return new FeatureFetch[0];
                 });
         } catch (Exception e) {
             showToast("Mapper Connect Error", "Check your internet connection?");
-            System.out.println("Failed to fetch features from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch features from PVC Mapper!", e);
             return CompletableFuture.completedFuture(new FeatureFetch[0]);
         }
     }
@@ -368,11 +361,11 @@ public class PlayerFetchUtils {
     }
 
     public CompletableFuture<FeatureTypes> fetchPlaceAsync(int placeId) {
-        System.out.println("Fetching place with ID: " + placeId);
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/fetch/places/byid/" + placeId))
+                .uri(new URI(NetworkUtils.API_V1 + "/fetch/places/byid/" + placeId))
                 .GET().build();
+            LogUtils.debug("Fetching place with ID: " + placeId + " from " + request.uri().toString());
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     FeatureTypes ft = new FeatureTypes();
@@ -383,20 +376,18 @@ public class PlayerFetchUtils {
                         showToast("Place not found!", "The place may have just been deleted.");
                     } else {
                         showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                        System.out.println("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
+                        LogUtils.error("Failed to fetch places from PVC Mapper! Code: " + response.statusCode());
                     }
                     return ft;
                 })
                 .exceptionally(e -> {
                     showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                    System.out.println("Failed to fetch places from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch places from PVC Mapper!", e);
                     return new FeatureTypes();
                 });
         } catch (Exception e) {
             showToast("Mapper Connect Error", "Problem connecting, try again later!");
-            System.out.println("Failed to fetch places from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch places from PVC Mapper!", e);
             return CompletableFuture.completedFuture(new FeatureTypes());
         }
     }
@@ -410,38 +401,36 @@ public class PlayerFetchUtils {
     }
 
     public CompletableFuture<FeatureTypes> fetchAreaAsync(int placeId) {
-        System.out.println("Fetching area with ID: " + placeId);
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/fetch/area/byid/" + placeId))
+                .uri(new URI(NetworkUtils.API_V1 + "/fetch/area/byid/" + placeId))
                 .GET().build();
+            LogUtils.debug("Fetching area with ID: " + placeId + " from " + request.uri().toString());
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     FeatureTypes ft = new FeatureTypes();
                     if (response.statusCode() == 200) {
                         Gson gson = new Gson();
                         ft.area = gson.fromJson(response.body(), AreasFetch.class);
-                        System.out.println("X/Z: " + ft.area.x + " / " + ft.area.z);
+                        LogUtils.debug("X/Z: " + ft.area.x + " / " + ft.area.z);
                         ft.area.x = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.x))));
                         ft.area.z = String.format("%d", (int)(metersToPixels(Double.parseDouble(ft.area.z))));
                     } else if (response.statusCode() == 404) {
                         showToast("Area not found!", "The area may have just been deleted.");
                     } else {
                         showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                        System.out.println("Failed to fetch areas from PVC Mapper! Code: " + response.statusCode());
+                        LogUtils.error("Failed to fetch areas from PVC Mapper! Code: " + response.statusCode());
                     }
                     return ft;
                 })
                 .exceptionally(e -> {
                     showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                    System.out.println("Failed to fetch areas from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch areas from PVC Mapper!", e);
                     return new FeatureTypes();
                 });
         } catch (Exception e) {
             showToast("Mapper Connect Error", "Problem connecting, try again later!");
-            System.out.println("Failed to fetch areas from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch areas from PVC Mapper!", e);
             return CompletableFuture.completedFuture(new FeatureTypes());
         }
     }
@@ -449,7 +438,7 @@ public class PlayerFetchUtils {
     public CompletableFuture<SearchResult[]> fetchSearchResultsAsync(String query) {
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v2/search/" + query))
+                .uri(new URI(NetworkUtils.API_V2 + "/search/" + query))
                 .GET().build();
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
@@ -462,20 +451,18 @@ public class PlayerFetchUtils {
                         return null;
                     } else {
                         showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                        System.out.println("Failed to fetch search from PVC Mapper! Code: " + response.statusCode());
+                        LogUtils.error("Failed to fetch search from PVC Mapper! Code: " + response.statusCode());
                         return null;
                     }
                 })
                 .exceptionally(e -> {
                     showToast("Mapper Connect Error", "Problem connecting, try again later!");
-                    System.out.println("Failed to fetch search from PVC Mapper!");
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch search from PVC Mapper!", e);
                     return null;
                 });
         } catch (Exception e) {
             showToast("Mapper Connect Error", "Problem connecting, try again later!");
-            System.out.println("Failed to fetch search from PVC Mapper!");
-            System.out.println(e);
+            LogUtils.error("Failed to fetch search from PVC Mapper!", e);
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -489,12 +476,12 @@ public class PlayerFetchUtils {
             // Just forget it, something weird's going on
             return;
         }
-        System.out.println("Checking for updates from https://pvc.coolwebsite.uk/mod/downloads/modversions.json...");
-        System.out.println("Current version: " + McVersionName + ", " + MapperModVersionName);
+        LogUtils.debug("Current version: %s, %s", McVersionName, MapperModVersionName);
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/mod/downloads/modversions.json"))
+                .uri(new URI(NetworkUtils.BASE_URL + "/mod/downloads/modversions.json"))
                 .GET().build();
+            LogUtils.debug("Checking for updates from " + request.uri().toString() + "...");
             NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenAccept(response -> {
                     if (response.statusCode() == 200) {
@@ -502,7 +489,7 @@ public class PlayerFetchUtils {
                         VersionHistory[] vh = gson.fromJson(response.body(), VersionHistory[].class);
                         for (int i = 0; i < vh.length; i++) {
                             if(vh[i].mcVersion.equals(McVersionName)) {
-                                System.out.println("Version for this MC version is found! v" + vh[i].version);
+                                LogUtils.debug("Version for this MC version is found! v" + vh[i].version);
                                 final String newVersion = vh[i].version;
                                 if(!newVersion.equals(MapperModVersionName)) {
                                     Minecraft.getInstance().execute(() -> {

--- a/src/client/java/larrytllama/pvcmappermod/SettingsProvider.java
+++ b/src/client/java/larrytllama/pvcmappermod/SettingsProvider.java
@@ -26,7 +26,7 @@ public class SettingsProvider {
 
     public boolean miniMapEnabled = true;
 
-    public String mapTileSource = "https://pvc.coolwebsite.uk/maps/";
+    public String mapTileSource = NetworkUtils.BASE_URL + "/maps/";
 
     public boolean useDarkTiles = false;
 
@@ -37,18 +37,20 @@ public class SettingsProvider {
     public BigMapPos bigMapPos = BigMapPos.CENTRE_ON_PLAYER;
 
     public boolean collectData = false;
+    
+    public boolean debugMode = false;
 
     Path path = FabricLoader.getInstance().getConfigDir().resolve("pvcmapper.json");
 
     public SettingsProvider() {
-        updateSettings();
+        // Initialization decoupled to PVCMapperModClient to prevent static initialization race conditions
     }
 
     public void updateSettings() {
         Gson gson = new Gson();
         if(Files.exists(path)) {
             try {
-                System.out.println(path.toString());
+                LogUtils.info("Loading config from: " + path.toString());
                 SettingsJSON settingsFromFile = gson.fromJson(Files.readString(path), SettingsJSON.class);
                 if(settingsFromFile.minimapScale != 0.0) minimapScale = settingsFromFile.minimapScale;
                 if(settingsFromFile.miniMapZoom != 0) miniMapZoom = settingsFromFile.miniMapZoom;
@@ -59,8 +61,9 @@ public class SettingsProvider {
                 if(settingsFromFile.bigMapPos != null) bigMapPos = settingsFromFile.bigMapPos;
                 checkForUpdates = settingsFromFile.checkForUpdates;
                 collectData = settingsFromFile.collectData;
+                debugMode = settingsFromFile.debugMode;
             } catch(Exception e) {
-                System.out.println(e);
+                LogUtils.error("Couldn't read settings file", e);
                 new SystemToast(SystemToastId.FILE_DROP_FAILURE, Component.literal("PVC Mapper Settings Error"), Component.literal("Couldn't open the Setting file, check you have permissions to access it!"));
             }
         } else {
@@ -79,7 +82,7 @@ public class SettingsProvider {
     }
 
     public void saveSettings() {
-        System.out.println("Saving settings!");
+        LogUtils.debug("Saving settings!");
         Gson gson = new Gson();
         SettingsJSON settingsToSet = new SettingsJSON();
         settingsToSet.mapTileSource = mapTileSource;
@@ -91,8 +94,9 @@ public class SettingsProvider {
         settingsToSet.bigMapPos = bigMapPos;
         settingsToSet.checkForUpdates = checkForUpdates;
         settingsToSet.collectData = collectData;
+        settingsToSet.debugMode = debugMode;
         try {
-            System.out.println("Writing to settings!" + path.getParent().toString());
+            LogUtils.debug("Writing to settings!" + path.getParent().toString());
             Files.createDirectories(path.getParent());
             Files.writeString(
                 path,
@@ -111,11 +115,12 @@ class SettingsJSON {
     double minimapScale = 1;
     MiniMapPositions miniMapPos = MiniMapPositions.TOP_RIGHT;
     boolean miniMapEnabled = true;
-    String mapTileSource = "https://pvc.coolwebsite.uk/maps/";
+    String mapTileSource = NetworkUtils.BASE_URL + "/maps/";
     boolean useDarkTiles = false;
     BigMapPos bigMapPos = BigMapPos.CENTRE_ON_PLAYER;
     boolean checkForUpdates = true;
     boolean collectData = false;
+    boolean debugMode = false;
 }
 
 enum MiniMapPositions {

--- a/src/client/java/larrytllama/pvcmappermod/ShopsHandler.java
+++ b/src/client/java/larrytllama/pvcmappermod/ShopsHandler.java
@@ -75,7 +75,7 @@ public class ShopsHandler {
     public static CompletableFuture<Shop[]> shopsByItemAsync(String item) {
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByItem/" + item))
+                .uri(new URI(NetworkUtils.BASE_URL + "/pvc-utils/tradesByItem/" + item))
                 .GET().build();
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
@@ -98,27 +98,27 @@ public class ShopsHandler {
 
     public static CompletableFuture<Shop[]> shopsByPlayerAsync(String username) {
         try {
-            System.out.println("Fetching shops for " + username);
+            LogUtils.debug("Fetching shops for " + username);
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/tradesByPlayer/" + username))
+                .uri(new URI(NetworkUtils.BASE_URL + "/pvc-utils/tradesByPlayer/" + username))
                 .GET().build();
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     if (response.statusCode() == 200) {
                         Gson gson = new GsonBuilder().registerTypeAdapter(Shop.class, new ShopDeserializer()).create();
                         Shop[] shops = gson.fromJson(response.body(), Shop[].class);
-                        System.out.println(shops.length);
+                        LogUtils.debug(shops.length);
                         return shops;
                     }
                     return new Shop[0];
                 })
                 .exceptionally(e -> {
-                    System.out.println(e);
+                    LogUtils.error("Failed to fetch shops by player", e);
                     e.printStackTrace();
                     return new Shop[0];
                 });
         } catch(Exception e) {
-            System.out.println(e);
+            LogUtils.error("Failed to fetch shops by player", e);
             e.printStackTrace();
             return CompletableFuture.completedFuture(new Shop[0]);
         }
@@ -128,7 +128,7 @@ public class ShopsHandler {
     public static CompletableFuture<ShopsPlayerStats> shopsStatsByPlayerAsync(String username) {
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/pvc-utils/playerStats/" + username))
+                .uri(new URI(NetworkUtils.BASE_URL + "/pvc-utils/playerStats/" + username))
                 .GET().build();
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
@@ -156,10 +156,10 @@ public class ShopsHandler {
 
     public static CompletableFuture<CustomItem[]> getCustomItems() {
         try {
-            System.out.println("Fetching custom item dict from PVC Mapper: https://pvc.coolwebsite.uk/api/v2/custom-items");
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v2/custom-items"))
+                .uri(new URI(NetworkUtils.API_V2 + "/custom-items"))
                 .GET().build();
+            LogUtils.debug("Fetching custom item dict from PVC Mapper: " + request.uri().toString());
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     if (response.statusCode() == 200) {
@@ -233,7 +233,7 @@ class ShopDeserializer implements JsonDeserializer<Shop> {
 
         JsonObject obj = json.getAsJsonObject();
         Shop shop = new Shop();
-        System.out.println("Applying properties");
+        LogUtils.debug("Applying properties");
         shop.currency = obj.get("currency").getAsString();
         shop.currency2 = obj.get("currency2").isJsonNull() ? null : obj.get("currency2").getAsString();
         shop.customName = obj.get("customName").isJsonNull() ? null : obj.get("customName").getAsString();
@@ -248,22 +248,22 @@ class ShopDeserializer implements JsonDeserializer<Shop> {
         shop.shopOwner = obj.get("shopOwner").getAsString();
         shop.stock = obj.get("stock").getAsInt();
         shop.tradeAmount = obj.get("tradeAmount").getAsInt();
-        System.out.println("Applying enchantments");
+        LogUtils.debug("Applying enchantments");
         // Get enchants as ShopEnchants
         try {
             JsonArray enchants = obj.get("enchants").getAsJsonArray();
             shop.enchants = new ShopEnchants[enchants.size()];
-            System.out.println("Applying " + enchants.size() + " enchantments");
+            LogUtils.debug("Applying " + enchants.size() + " enchantments");
             // Put em all in!
             for (int se = 0; se < enchants.size(); se++) {
                 JsonObject enchant = enchants.get(se).getAsJsonObject();
                 String enchantID = enchant.keySet().iterator().next();
                 int level = enchant.get(enchantID).getAsInt();
-                System.out.println("Parsed enchant - ID: " + enchantID + ", Level: " + level);
+                LogUtils.debug("Parsed enchant - ID: " + enchantID + ", Level: " + level);
                 shop.enchants[se] = new ShopEnchants();
                 shop.enchants[se].id = enchantID;
                 shop.enchants[se].level = level;
-                System.out.println("Set enchant - ID: " + shop.enchants[se].id + ", Level: " + shop.enchants[se].level);
+                LogUtils.debug("Set enchant - ID: " + shop.enchants[se].id + ", Level: " + shop.enchants[se].level);
             }
         } catch(Exception e) {
             shop.enchants = new ShopEnchants[0];

--- a/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
+++ b/src/client/java/larrytllama/pvcmappermod/ShopsScreen.java
@@ -102,7 +102,7 @@ public class ShopsScreen extends Screen {
         searchBtn = new Button.Builder(Component.empty(), (b) -> {
             if(currentSearchMode.equals("item")) this.openWithItem(this.itemSearch.getValue());
             else if(currentSearchMode.equals("username")) this.openWithUsername(this.itemSearch.getValue());
-            else System.out.println("Unknown search mode error");
+            else LogUtils.error("Unknown search mode error");
         }).bounds( this.width - 35, this.height - 35, 20, 20).build();
 
         this.addRenderableWidget(searchBtn);
@@ -115,7 +115,7 @@ public class ShopsScreen extends Screen {
                 minecraft.font.width("Search by: username") + 10, minecraft.font.lineHeight + 10, 
                 Component.literal("Search by"), (btn, value) -> {
                     currentSearchMode = value;
-                    System.out.println(value);
+                    LogUtils.debug(value);
                     switch (value) {
                         case "item":
                             itemSearch.setHint(Component.literal("e.g PLAYTIME_CERTIFICATE"));
@@ -141,6 +141,9 @@ public class ShopsScreen extends Screen {
                     Component.literal(banner.description));
             sponsorURLString = banner.link;
         });
+
+        this.setInitialFocus(itemSearch);
+        this.setFocused(itemSearch);
     }
 
     @Override
@@ -150,7 +153,9 @@ public class ShopsScreen extends Screen {
             else Minecraft.getInstance().setScreen(null);
         } else if(itemSearch.isFocused()) {
             if(keyEvent.key() == GLFW.GLFW_KEY_TAB) {
-                itemSearch.setValue(filteredItems[0]);
+                if (filteredItems != null && filteredItems.length > 0 && filteredItems[0] != null) {
+                    itemSearch.setValue(filteredItems[0]);
+                }
             } else if(keyEvent.key() == GLFW.GLFW_KEY_ENTER) {
                 if(currentSearchMode.equals("item")) this.openWithItem(this.itemSearch.getValue());
                 else if(currentSearchMode.equals("username")) this.openWithUsername(this.itemSearch.getValue());
@@ -214,16 +219,6 @@ public class ShopsScreen extends Screen {
     ResourceLocation blurredTile = ResourceLocation.fromNamespaceAndPath("pvcmappermod", "textures/gui/tileloading.png");
     ResourceLocation villagerImg = ResourceLocation.fromNamespaceAndPath("pvcmappermod", "textures/gui/villager.png");
 
-    public void fetchTile(int tileX, int tileZ, String dimension) {
-        tiles.put(String.format("%s/8/%d_%d", dimension, tileX, tileZ), blurredTile);
-        // Make a request for the tile
-        String url = String.format("%s%s/8/%d_%d.png",
-            "https://pvc.coolwebsite.uk/maps/", dimension, tileX, tileZ);
-        TextureUtils.fetchImmediateRemoteTexture(url, (id) -> {
-            tiles.put(String.format("%s/8/%d_%d", dimension, tileX, tileZ), id);
-        });
-    }
-
     // Trace meeeee
     public void drawMap(GuiGraphics graphics, int x, int y, int width, int height, int coordX, int coordZ, String dimension) {
         graphics.enableScissor(x, y, x+width, y+height);
@@ -236,13 +231,15 @@ public class ShopsScreen extends Screen {
                 int tileX = ((int)Math.floor(coordX / 512))+ iX -1;
                 int tileZ = ((int)Math.floor(coordZ / 512))+ iZ -1;
 
-                ResourceLocation tile = tiles.get(String.format("%s/8/%d_%d", dimension, tileX, tileZ));
+                String url = String.format("%s%s/8/%d_%d.png", SettingsProvider.getInstance().mapTileSource, dimension, tileX, tileZ);
+                ResourceLocation tile = TextureUtils.getCachedTexture(url);
+                
                 if(tile == null) {
-                    fetchTile(tileX, tileZ, dimension);
-                } else {
-                    graphics.blit(RenderPipelines.GUI_TEXTURED, tile, (512 * iX), (512 * iZ), 0, 0, 512, 512, 512, 512);
+                    TextureUtils.fetchImmediateRemoteTexture(url, (id) -> {});
+                    tile = TextureUtils.blurredTile;
                 }
-
+                
+                graphics.blit(RenderPipelines.GUI_TEXTURED, tile, (512 * iX), (512 * iZ), 0, 0, 512, 512, 512, 512);
             }
         }
         graphics.pose().popMatrix();
@@ -641,7 +638,7 @@ class MyList extends ContainerObjectSelectionList<MyList.Entry> {
                     }
                 }
             } catch(Exception e) {
-                System.out.println(e);
+                LogUtils.error("Error rendering item in list", e);
                 graphics.blit(RenderPipelines.GUI_TEXTURED, UNKNOWN_ITEM, 77, y + 3, 0, 0, 12, 12, 12, 12);
             }
             

--- a/src/client/java/larrytllama/pvcmappermod/SponsorUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/SponsorUtils.java
@@ -23,11 +23,11 @@ class SponsorBanner {
 
 public class SponsorUtils {
     public static CompletableFuture<SponsorBanner> getBannerAsync() {
-        System.out.println("Fetching sponsor banner from https://pvc.coolwebsite.uk/api/v1/sponsor-banner...");
         try {
             java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
-                .uri(new URI("https://pvc.coolwebsite.uk/api/v1/sponsor-banner"))
+                .uri(new URI(NetworkUtils.API_V1 + "/sponsor-banner"))
                 .GET().build();
+            LogUtils.debug("Fetching sponsor banner from " + request.uri().toString() + "...");
             return NetworkUtils.HTTP_CLIENT.sendAsync(request, java.net.http.HttpResponse.BodyHandlers.ofString())
                 .thenApply(response -> {
                     if (response.statusCode() == 200) {
@@ -38,13 +38,11 @@ public class SponsorUtils {
                     return new SponsorBanner();
                 })
                 .exceptionally(e -> {
-                    System.out.println("Failed to fetch sponsor banners");
-                    e.printStackTrace();
+                    LogUtils.error("Failed to fetch sponsor banners", e);
                     return new SponsorBanner();
                 });
         } catch(Exception e) {
-            System.out.println("Failed to fetch sponsor banners");
-            e.printStackTrace();
+            LogUtils.error("Failed to fetch sponsor banners", e);
             return CompletableFuture.completedFuture(new SponsorBanner());
         }
     }
@@ -70,8 +68,7 @@ public class SponsorUtils {
                 callback.accept(resourceLocation);
             });
         } catch(Exception e) {
-            System.out.println("Error converting data to image content:");
-            System.out.println(e);
+            LogUtils.error("Error converting data to image content:", e);
             callback.accept(null);
         }
 

--- a/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
+++ b/src/client/java/larrytllama/pvcmappermod/TextureUtils.java
@@ -12,34 +12,64 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TextureUtils {
     // Limits background tile downloads to prevent Cloudflare rate-limiting.
     // Increased to 16 from 7-8 because the Stagger logic below prevents bursts. Could try higher.
-    private static final int MAX_CONCURRENT_DOWNLOADS = 20;
+    private static final int MAX_CONCURRENT_DOWNLOADS = 25;
     
     // Global stagger to prevent Cloudflare/Origin challenges during initialization's fetches.
     private static final java.util.concurrent.atomic.AtomicLong lastFetchTime = new java.util.concurrent.atomic.AtomicLong(0);
     private static final int FETCH_STAGGER_MS = 50;
 
-    // LIFO ThreadPool: Prioritizes the most recently requested tiles over older, off-screen tiles.
-    private static final ExecutorService downloadExecutor = new ThreadPoolExecutor(
-            MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_DOWNLOADS, 0L, TimeUnit.MILLISECONDS,
-            new LinkedBlockingDeque<Runnable>() {
-                @Override
-                public boolean offer(Runnable e) {
-                    return super.offerFirst(e);
-                }
-            }
-    );
+    // LIFO Queue for pending downloads. Prioritizes the most recently requested tiles.
+    private static final LinkedBlockingDeque<Runnable> fetchQueue = new LinkedBlockingDeque<>();
+    private static final java.util.concurrent.atomic.AtomicInteger activeDownloads = new java.util.concurrent.atomic.AtomicInteger(0);
     private static final ConcurrentHashMap<String, Long> failedFetches = new ConcurrentHashMap<>();
+
+    private static void pumpQueue() {
+        while (activeDownloads.get() < MAX_CONCURRENT_DOWNLOADS) {
+            Runnable task = fetchQueue.pollFirst();
+            if (task == null) break;
+            
+            activeDownloads.incrementAndGet();
+            Thread.ofVirtual().start(() -> {
+                try {
+                    task.run();
+                } finally {
+                    activeDownloads.decrementAndGet();
+                    pumpQueue();
+                }
+            });
+        }
+    }
+    
+    private static final int MAX_CACHED_TILES = 200;
+    
+    // LRU Cache for managing memory limit
+    private static final java.util.Map<String, ResourceLocation> tileCache = java.util.Collections.synchronizedMap(
+        new java.util.LinkedHashMap<String, ResourceLocation>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(java.util.Map.Entry<String, ResourceLocation> eldest) {
+                if (size() > MAX_CACHED_TILES) {
+                    ResourceLocation id = eldest.getValue();
+                    net.minecraft.client.Minecraft.getInstance().getTextureManager().release(id);
+                    activeTiles.decrementAndGet();
+                    return true;
+                }
+                return false;
+            }
+        }
+    );
+    
+    // Memory Profiling Counter
+    public static final java.util.concurrent.atomic.AtomicInteger activeTiles = new java.util.concurrent.atomic.AtomicInteger(0);
     
     static ResourceLocation blurredTile = ResourceLocation.fromNamespaceAndPath("pvcmappermod","textures/gui/tileloading.png");
+
+    private static final ConcurrentHashMap<String, Boolean> pendingFetches = new ConcurrentHashMap<>();
 
     /**
      * Fetches an image from a URL, converts it to a DynamicTexture, registers it,
@@ -49,6 +79,12 @@ public class TextureUtils {
      * @param callback  The callback to run when the texture is ready.
      */
     public static void fetchRemoteTexture(String urlString, Consumer<ResourceLocation> callback) {
+        ResourceLocation cached = tileCache.get(urlString);
+        if (cached != null) {
+            callback.accept(cached);
+            return;
+        }
+
         Long failedTime = failedFetches.get(urlString);
         if (failedTime != null && (System.currentTimeMillis() - failedTime < 10000)) {
             // Already failed recently. Use blurred tile silently.
@@ -56,10 +92,17 @@ public class TextureUtils {
             return;
         }
 
-        System.out.println("Fetching image from source: " + urlString);
-        downloadExecutor.submit(() -> {
+        if (pendingFetches.putIfAbsent(urlString, Boolean.TRUE) != null) {
+            // Already fetching
+            callback.accept(blurredTile);
+            return;
+        }
+
+        LogUtils.debug("Fetching image from source: " + urlString);
+        fetchQueue.addFirst(() -> {
             executeFetch(urlString, callback);
         });
+        pumpQueue();
     }
 
     /**
@@ -67,9 +110,36 @@ public class TextureUtils {
      * Intended exclusively for UI elements like POI overlays and banners.
      */
     public static void fetchImmediateRemoteTexture(String urlString, Consumer<ResourceLocation> callback) {
-        System.out.println("Fetching immediate UI image from source: " + urlString);
-        CompletableFuture.runAsync(() -> {
+        ResourceLocation cached = tileCache.get(urlString);
+        if (cached != null) {
+            callback.accept(cached);
+            return;
+        }
+
+        if (pendingFetches.putIfAbsent(urlString, Boolean.TRUE) != null) {
+            callback.accept(blurredTile);
+            return;
+        }
+
+        LogUtils.debug("Fetching immediate UI image from source: " + urlString);
+        Thread.ofVirtual().start(() -> {
             executeFetch(urlString, callback);
+        });
+    }
+
+    public static ResourceLocation getCachedTexture(String urlString) {
+        return tileCache.get(urlString);
+    }
+
+    public static void clearCache() {
+        Minecraft.getInstance().execute(() -> {
+            for (ResourceLocation id : tileCache.values()) {
+                Minecraft.getInstance().getTextureManager().release(id);
+                activeTiles.decrementAndGet();
+            }
+            tileCache.clear();
+            pendingFetches.clear();
+            failedFetches.clear();
         });
     }
 
@@ -85,7 +155,7 @@ public class TextureUtils {
         } catch (InterruptedException ignored) {}
 
         try {
-            String targetUrl = urlString.startsWith("https://") ? urlString : "https://pvc.coolwebsite.uk" + urlString;
+            String targetUrl = urlString.startsWith("https://") ? urlString : NetworkUtils.BASE_URL + urlString;
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(new URI(targetUrl))
                     .GET()
@@ -95,14 +165,20 @@ public class TextureUtils {
             HttpResponse<InputStream> response = NetworkUtils.HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
             if (response.statusCode() == 404) {
-                Minecraft.getInstance().execute(() -> callback.accept(blurredTile));
+                Minecraft.getInstance().execute(() -> {
+                    pendingFetches.remove(urlString);
+                    callback.accept(blurredTile);
+                });
                 return;
             }
             
             if (response.statusCode() != 200) {
-                System.out.println("[TextureUtils Error] Failed to fetch tile: " + urlString + " (HTTP " + response.statusCode() + ")");
+                LogUtils.warn("[TextureUtils] Failed to fetch tile: " + urlString + " (HTTP " + response.statusCode() + ")");
                 failedFetches.put(urlString, System.currentTimeMillis());
-                Minecraft.getInstance().execute(() -> callback.accept(blurredTile)); // using blurredTile so we don't return null
+                Minecraft.getInstance().execute(() -> {
+                    pendingFetches.remove(urlString);
+                    callback.accept(blurredTile); // using blurredTile so we don't return null
+                });
                 return;
             }
 
@@ -127,6 +203,13 @@ public class TextureUtils {
                 //dynamicTexture
                 ResourceLocation resourceLocation = ResourceLocation.fromNamespaceAndPath("pvcmappermod", idStr);
                 Minecraft.getInstance().getTextureManager().register(resourceLocation, dynamicTexture);
+                tileCache.put(urlString, resourceLocation);
+                
+                int currentTiles = activeTiles.incrementAndGet();
+                int osThreads = java.lang.management.ManagementFactory.getThreadMXBean().getThreadCount();
+                LogUtils.debug("[Memory Profiling] Active Map Tiles Loaded: %d (Est. VRAM: %.2f MB) | OS Threads: %d", currentTiles, currentTiles * 0.25, osThreads);
+                
+                pendingFetches.remove(urlString);
                 callback.accept(resourceLocation);
                 failedFetches.remove(urlString); // clear cache on success
             });
@@ -138,9 +221,11 @@ public class TextureUtils {
                 return;
             }
 
-            System.err.println("[TextureUtils Error] Exception while fetching URL: " + urlString);
-            Minecraft.getInstance().execute(() -> callback.accept(null));
-            e.printStackTrace();
+            LogUtils.warn("[TextureUtils Error] Exception while fetching URL: " + urlString, e);
+            Minecraft.getInstance().execute(() -> {
+                pendingFetches.remove(urlString);
+                callback.accept(null);
+            });
         }
     }
 


### PR DESCRIPTION
# 🚀 Performance Overhaul: Memory caching, Virtual Threads, and UI speed

I went through to address some memory leaks, and ended up changing the tech to further optimize the fetching pipeline. As a result, the map now loads significantly faster and runs much lighter on the system.

## Executive Summary (gotta keep my corporate skills up)
* **Speed improvements & new zoom level 9:** Map panning is 20% faster. I also added support for overzoom (level 9), which just upscales level 8 tiles locally. Increased concurrent downloads from 20 to 25.
* **Memory (VRAM) reduction:** Fixed a silent leak where orphaned tiles weren't being destroyed. We went from leaking **165MB+ (660+ tiles)** after a minute of panning, down to a perfectly flat, safe ceiling of **~50MB (200 tiles)**.
* **Zero-cost threading:** Swapped heavy OS threads for Java 21 Virtual Threads. The mod can now process 25 concurrent background tile downloads while keeping OS thread usage completely flat (saving context-switch overhead and stack RAM).
* **Standardized logging and URL reporting:** Most console spam is gone, unless you want it. All `println`s are moved to a `LogUtils` class, and most output is only visible if new "Debug Mode" is enabled in settings.

## Notes
* **Centralized LRU cache:** Stripped localized tile tracking out of `FullScreenMap` and `Minimap`. Both UIs now synchronously call a centralized `TextureUtils.getCachedTexture(url)`. When the `LinkedHashMap` cache exceeds 200 tiles, the oldest tile is explicitly destroyed via `TextureManager.release()`.
* **Virtual thread LIFO dispatcher:** Replaced the old `ThreadPoolExecutor` LIFO with a `LinkedBlockingDeque` pump using `Thread.ofVirtual()`. This was inspired by figuring out what kind of improvements we might get from Java 25 and realized the features I wanted were already in Java 21.